### PR TITLE
bqn-mode.el (bqn-mode): Add comment-start to bqn-mode

### DIFF
--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -30,7 +30,8 @@
   :group 'bqn
   (use-local-map bqn--mode-map)
   (setq-local font-lock-defaults bqn--token-syntax-types)
-  (setq-local eldoc-documentation-function 'bqn-help--eldoc))
+  (setq-local eldoc-documentation-function 'bqn-help--eldoc)
+  (setq-local comment-start "# "))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.bqn\\'" . bqn-mode))


### PR DESCRIPTION
With `comment-start` we can use `comment-dwim`; usually bound to `M-;`.