### PR TITLE
bqn-symbols-doc: require relevant feature for hash tables

### DIFF
--- a/bqn-symbols-doc.el
+++ b/bqn-symbols-doc.el
@@ -17,6 +17,8 @@
 ;;
 ;;; Code:
 
+(require 'subr-x)
+
 ;; a hash and array is not very emacs-lisp-y but because this will be user
 ;; facing, so we want the lowest latency possible. This hash should be treated
 ;; as read-only.


### PR DESCRIPTION
subr-x.el implements hash-table-keys. Emacs HEAD currently fails to
compile bqn-symbols-doc.el if we don't load this explicitly. Seems like
it was loaded implicitly before for some reason.