### PR TITLE
Make bqn-mode a multi-file package

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-BQN's emacs mode is derived from gnu-apl-mode,
+Emacs bqn-mode is derived from gnu-apl-mode,
 which is copyright 2013-2015 Elias Mårtenson <lokedhs@gmail.com>.
 Changes are copyright 2021 Marshall Lochbaum <mwlochbaum@gmail.com>.
 

--- a/bqn-mode-pkg.el
+++ b/bqn-mode-pkg.el
@@ -1,0 +1,3 @@
+(define-package "bqn-mode" "0.1.0"
+  "Emacs mode for BQN."
+  '((cl-lib "0.5")))

--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -1,14 +1,23 @@
-;;; bqn-mode --- Emacs mode for BQN -*- lexical-binding: t -*-
-;;;
+;;; bqn-mode.el --- Emacs mode for BQN -*- lexical-binding: t -*-
+
+;; BQN's emacs mode is derived from gnu-apl-mode,
+;; which is copyright 2013-2015 Elias Mårtenson <lokedhs@gmail.com>.
+;; Changes are copyright 2021 Marshall Lochbaum <mwlochbaum@gmail.com>.
+
+;; Author: Marshall Lochbaum <mwlochbaum@gmail.com>
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "24") (cl-lib "0.5"))
+;; URL: https://github.com/museoa/bqn-mode
+
 ;;; Commentary:
-;;;
-;;; Emacs mode for BQN: currently keymap only
-;;;
-;;; There are two ways to access the BQN keymap:
-;;; - When editing a BQN file, use keys with the super (s-) modifier.
-;;; - Enable backslash prefixes by entering C-\ (‘toggle-input-method’)
-;;;   then BQN-Z. Then enter backslash \ before a key.
-;;;
+
+;; Emacs mode for BQN: currently keymap only
+
+;; There are two ways to access the BQN keymap:
+;; - When editing a BQN file, use keys with the super (s-) modifier.
+;; - Enable backslash prefixes by entering C-\ (‘toggle-input-method’)
+;;   then BQN-Z. Then enter backslash \ before a key.
+
 ;;; Code:
 
 (require 'bqn-input)
@@ -45,3 +54,4 @@
   (speedbar-add-supported-extension ".bqn"))
 
 (provide 'bqn-mode)
+;;; bqn-mode.el ends here

--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -5,7 +5,7 @@
 ;; Changes are copyright 2021 Marshall Lochbaum <mwlochbaum@gmail.com>.
 
 ;; Author: Marshall Lochbaum <mwlochbaum@gmail.com>
-;; Version: 0.1.0
+;; Version: 0.0.0
 ;; Package-Requires: ((emacs "24") (cl-lib "0.5"))
 ;; URL: https://github.com/museoa/bqn-mode
 

--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -1,6 +1,6 @@
 ;;; bqn-mode.el --- Emacs mode for BQN -*- lexical-binding: t -*-
 
-;; BQN's emacs mode is derived from gnu-apl-mode,
+;; Emacs bqn-mode is derived from gnu-apl-mode,
 ;; which is copyright 2013-2015 Elias Mårtenson <lokedhs@gmail.com>.
 ;; Changes are copyright 2021 Marshall Lochbaum <mwlochbaum@gmail.com>.
 


### PR DESCRIPTION
This addresses issue #1, and should be sufficient for submitting bqn-mode to melpa.

You can test installing the package by opening the directory containing bqn-mode in dired, and running `package-install-from-buffer`.

It is required to add a version number, so I chose version `0.1.0` a bit arbitrarily.

If this pr is accepted, then I can add it to [https://melpa.org/](melpa) as well!