### PR TITLE
Remove speedbar config and downgrade Emacs-version dependency

### DIFF
--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -6,7 +6,7 @@
 
 ;; Author: Marshall Lochbaum <mwlochbaum@gmail.com>
 ;; Version: 0.0.0
-;; Package-Requires: ((emacs "24") (cl-lib "0.5"))
+;; Package-Requires: ((emacs "24.3"))
 ;; URL: https://github.com/museoa/bqn-mode
 
 ;;; Commentary:
@@ -49,9 +49,6 @@
 
 ;;;###autoload
 (add-to-list 'interpreter-mode-alist '("bqn" . bqn-mode))
-
-(with-eval-after-load 'speedbar
-  (speedbar-add-supported-extension ".bqn"))
 
 (provide 'bqn-mode)
 ;;; bqn-mode.el ends here


### PR DESCRIPTION
These are both results of running [package-lint](https://github.com/purcell/package-lint), which is done in preparation for adding bqn-mode to melpa (#1).

This should probably have been a part of #11.

It seems that setting up speedbar should be a user configuration, rather than something the package does by itself. I see some packages include how to set it up in their documentation. The linter complained because of the use of `with-eval-after-load`, which is okay for user configs, but not for packages. Because`bqn-mode` doesn't depend on speedbar, I figured it best to remove it.
