### PR TITLE
[fixup] bqn-comint.el: require bqn-key-prefix

### DIFF
--- a/bqn-comint.el
+++ b/bqn-comint.el
@@ -12,6 +12,7 @@
 ;;; Code:
 
 (require 'comint)
+(require 'bqn-key-prefix)
 (require 'bqn-syntax)
 
 (defcustom bqn-comint-interpreter-path "bqn"


### PR DESCRIPTION
Fixes the error `Error: Can’t activate input method ‘BQN-Z’` as reported by https://github.com/museoa/bqn-mode/issues/23