### PR TITLE
[wip] bqn-symbols-doc.el: improve symbol-doc-table generation

### DIFF
--- a/bqn-symbols-doc.el
+++ b/bqn-symbols-doc.el
@@ -23,7 +23,8 @@
 ;; structure. For all intents and purposes, this table should be regarded as
 ;; read-only; indeed, it is "cached" at byte-compile time via eval-when-compile
 (defconst bqn-symbols-doc--symbol-doc-table
-  (let ((table '(
+  (eval-when-compile
+    (let ((table '(
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; The format of each entry follows the model below
 ;;; (<symb> . [short-description long-description extra-examples])
@@ -33,16 +34,16 @@
 ;;; - long-description should state what symbol is and what forms symbol has
 ;;; - extra-examples should provide minimal examples
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-                 ("+" .
-                  ["Monad: Conjugate | Dyad: Addition | Input: +"
-                   "+ is a function.
+                   ("+" .
+                    ["Monad: Conjugate | Dyad: Addition | Input: +"
+                     "+ is a function.
 - Its monadic form conjugates.
 - Its dyadic form is addition.
 - Can be applied to numbers, arrays and characters. For characters, uses an
 affine space relative to the linear space of numbers. Thus, 'a' + 2 is valid but
 'a' + 'b' is not.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 NOTE: Not implemented yet.
 
@@ -61,14 +62,14 @@ NOTE: Not implemented yet.
    at 'a' + 'b'
           ^
 "])
-                 ("-" .
-                  ["Monad: Negation | Dyad: Subtraction | Input: -"
-                   "- is a function.
+                   ("-" .
+                    ["Monad: Negation | Dyad: Subtraction | Input: -"
+                     "- is a function.
 - Its monadic form negates.
 - Its dyadic form subtracts.
 Can be applied to characters.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 -0
    ¯0
@@ -98,16 +99,16 @@ Can be applied to characters.
 'c' - \"abc\"
    ⟨ 2 1 0 ⟩
 "])
-                 ("×" .
-                  ["Monad: Sign | Dyad: Multiplication | Input: \\="
-                   "× is a function.
+                   ("×" .
+                    ["Monad: Sign | Dyad: Multiplication | Input: \\="
+                     "× is a function.
 - Its monadic form returns the sign of its argument:
   -  no sign (zero) =>  0
   -  positive sign  =>  1
   -  negative sign  =>  ¯1
 -Its dyadic form multiplies.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 × 0
   0
@@ -144,14 +145,14 @@ Note:
     2 ⋆⁼ 1024 => 10
     10 ⋆⁼ 100 => 2
 "])
-                 ("÷" .
-                  ["Monad: Reciprocal | Dyad: Divide | Input: \\-"
-                   "÷ is a function.
+                   ("÷" .
+                    ["Monad: Reciprocal | Dyad: Divide | Input: \\-"
+                     "÷ is a function.
 - Its monadic form computes 1÷x, where x is ÷'s argument.
 - Its dyadic form is division.
 "
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ÷ 0
   ∞
@@ -176,13 +177,13 @@ Note:
    1‿2‿3 ÷ 1‿2
          ^
 "])
-                 ("⋆" .
-                  ["Monad: Exponential | Dyad: Power | Input: \\+"
-                   "⋆ is a function.
+                   ("⋆" .
+                    ["Monad: Exponential | Dyad: Power | Input: \\+"
+                     "⋆ is a function.
 - Its monadic form raises its argument to euler's number.
 - Its dyadic form raises 𝕨 to 𝕩.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⋆ 0
    1
@@ -210,13 +211,13 @@ Note:
    0‿1‿2 ⋆ 2‿3‿4‿5
          ^
 "])
-                 ("√" .
-                  ["Monad: Square Root | Dyad: Root | Input: \\_"
-                   "√ is a function.
+                   ("√" .
+                    ["Monad: Square Root | Dyad: Root | Input: \\_"
+                     "√ is a function.
 - Its monadic form computes the square root of its argument.
 - Its dyadic form computes the root of 𝕩 with the degree 𝕨.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 √4
    2
@@ -232,13 +233,13 @@ Note:
 ¯0‿0‿¯2‿2‿¯2 √ 1‿¯1‿¯1‿4‿4
    ⟨ 1 1 NaN 2 0.5 ⟩
 "])
-                 ("⌊" .
-                  ["Monad: Floor | Dyad: Minimum | Input: \\b"
-                   "⌊ is a function.
+                   ("⌊" .
+                    ["Monad: Floor | Dyad: Minimum | Input: \\b"
+                     "⌊ is a function.
 - Its monadic form returns the floor of its argument.
 - Its dyadic form returns the minimum of its arguments.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⌊ π
    3
@@ -256,13 +257,13 @@ Note:
 Note:
   To take a minimum of an entire list, use the fold: ⌊´ (\\b\\5)
 "])
-                 ("⌈" .
-                  ["Monad: Ceiling | Dyad: Maximum | Input: \\B"
-                   "⌈ is a function.
+                   ("⌈" .
+                    ["Monad: Ceiling | Dyad: Maximum | Input: \\B"
+                     "⌈ is a function.
 - Its monadic form returns the ceiling of its argument.
 - Its dyadic form returns the maximum of its arguments.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
  ⌈ π
    4
@@ -280,13 +281,13 @@ Note:
 Note:
   To take a maximum of an entire list, use the fold: ⌈´ (\\B\\5)
 "])
-                 ("|" .
-                  ["Monad: Absolute Value | Dyad: Modulus | Input: |"
-                   "| is a function.
+                   ("|" .
+                    ["Monad: Absolute Value | Dyad: Modulus | Input: |"
+                     "| is a function.
 - Its monadic form returns the absolute value of its argument.
 - Its dyadic form returns the remainder resulting from division of 𝕩 by 𝕨.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 | ¯1
    1
@@ -308,9 +309,9 @@ Note:
 0 | ∞
    NaN
 "])
-                 ("=" .
-                  ["Monad: Rank | Dyad: Equals | Input: ="
-                   "= is a function.
+                   ("=" .
+                    ["Monad: Rank | Dyad: Equals | Input: ="
+                     "= is a function.
 - Its monadic form returns the rank of its input.
 - Its dyadic form tests for atomic equality of its arguments:
   - Found to be equal     => 1
@@ -320,7 +321,7 @@ Note:
 - characters are equal if they have the same code point (i.e c - @, where c is
   the char).
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 = 'a'
    0
@@ -343,16 +344,16 @@ Even ← 0=2|⊣
 Even ↕10
    ⟨ 1 0 1 0 1 0 1 0 1 0 ⟩
 "])
-                 ("≠" .
-                  ["Monad: Length | Dyad: Not Equals | Input: \\\/"
-                   "≠ is a function.
+                   ("≠" .
+                    ["Monad: Length | Dyad: Not Equals | Input: \\\/"
+                     "≠ is a function.
 - Its monadic form returns the length of its input.
 - Its dyadic form tests for atomic inequality of its arguments:
   - Found to be not equal     => 1
   - Not found to be not equal => 0
 Note: values of different types can never be equal.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ≠ 'a'
    1
@@ -368,30 +369,30 @@ Note: values of different types can never be equal.
 'b' ≠ \"abacba\"
    ⟨ 1 0 1 1 0 1 ⟩
 "])
-                 ("≤" .
-                  ["Dyad: Less than or equal | Input: \\<"
-                   "≤ is a function.
+                   ("≤" .
+                    ["Dyad: Less than or equal | Input: \\<"
+                     "≤ is a function.
 - It has no monadic form.
 - Its dyadic form tests for less than or equal to:
 "
-                   "Examples:
+                     "Examples:
 "])
-                 ("≥" .
-                  ["Dyad: Greater than or equal | Input: \\>"
-                   "≥ is a function.
+                   ("≥" .
+                    ["Dyad: Greater than or equal | Input: \\>"
+                     "≥ is a function.
 - It has no monadic form.
 - Its dyadic form tests for greater than or equal to.
 "
-                   "Examples
+                     "Examples
 "])
-                 ("<" .
-                  ["Monad: Enclose | Dyad: Less than | Input: <"
-                   "< is a function.
+                   ("<" .
+                    ["Monad: Enclose | Dyad: Less than | Input: <"
+                     "< is a function.
 - Its monadic form returns its argument in a unit array.
 - Its dyadic form returns the result comparing 𝕨 with 𝕩.
 Note: characters are always considered greater than numbers, even ∞.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 < \"singleton\"
    ┌·
@@ -424,15 +425,15 @@ Note: characters are always considered greater than numbers, even ∞.
 'a' < ∞
    0
 "])
-                 (">" .
-                  ["Monad: Merge | Dyad: Greater than | Input: >"
-                   "> is a function.
+                   (">" .
+                    ["Monad: Merge | Dyad: Greater than | Input: >"
+                     "> is a function.
 - It monadic form ensures that any inner arrays, in its argument, can fit
   together in an array (i.e. flatten ragged inner arrays).
 - Its dyadic form returns the result comparing 𝕨 with 𝕩.
 Note: characters are always considered greater than numbers, even ∞.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 a ← \"AB\"‿\"CD\" ∾⌜ \"rst\"‿\"uvw\"‿\"xyz\"
    ┌─
@@ -468,14 +469,14 @@ a ← \"AB\"‿\"CD\" ∾⌜ \"rst\"‿\"uvw\"‿\"xyz\"
 ∞ > 'z'
    0
 "])
-                 ("∧" .
-                  ["Monad: Sort Up | Dyad: Logical And | Input: \\t"
-                   "∧ is a function.
+                   ("∧" .
+                    ["Monad: Sort Up | Dyad: Logical And | Input: \\t"
+                     "∧ is a function.
 - Its monadic form reorders the major cells of its argument to place them in
   ascending order.
 - Its dyadic form returns the result of a logical And on the input arguments.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ∧ \"delta\"‿\"alpha\"‿\"beta\"‿\"gamma\"
    ⟨ \"alpha\" \"beta\" \"delta\" \"gamma\" ⟩
@@ -508,14 +509,14 @@ a ← \"AB\"‿\"CD\" ∾⌜ \"rst\"‿\"uvw\"‿\"xyz\"
 ∧´ 'a'≤ \"purple\"
    1
 "])
-                 ("∨" .
-                  ["Monad: Sort Down | Dyad: Logical Or | Input: \\v"
-                   "∨ is a function.
+                   ("∨" .
+                    ["Monad: Sort Down | Dyad: Logical Or | Input: \\v"
+                     "∨ is a function.
 - Its monadic form reorders the major cells of its argument to place them in
   descending order.
 - Its dyadic form returns the result of a logical Or on the input arguments.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ∨ \"delta\"‿\"alpha\"‿\"beta\"‿\"gamma\"
    ⟨ \"gamma\" \"delta\" \"beta\" \"alpha\" ⟩
@@ -548,9 +549,9 @@ a ← \"AB\"‿\"CD\" ∾⌜ \"rst\"‿\"uvw\"‿\"xyz\"
 ∨´ 'z'≤ \"purple\"
    0
 "])
-                 ("¬" .
-                  ["Monad: Not | Dyad: Span | Input: \\~"
-                   "¬ is a function.
+                   ("¬" .
+                    ["Monad: Not | Dyad: Span | Input: \\~"
+                     "¬ is a function.
 - Its monadic form returns the Boolean negation of its input.
 - Its dyadic form returns the number of integers separating 𝕨 from 𝕩, inclusive,
   only when 𝕩≤𝕨 and both are integers.
@@ -558,7 +559,7 @@ Note: defined as the fork, 1+-
       - considered an arithmetic function.
       - considered pervasive.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ¬ 0
    1
@@ -589,16 +590,16 @@ Note: defined as the fork, 1+-
 'a' ¬ @
    98
 "])
-                 ("≡" .
-                  ["Monad: Depth | Dyad: Match | Input: \\m"
-                   "≡ is a function.
+                   ("≡" .
+                    ["Monad: Depth | Dyad: Match | Input: \\m"
+                     "≡ is a function.
 - Its monadic form returns the depth (i.e. the level of nesting) of its input.
 - Its dyadic form tests equivalency between 𝕩 and 𝕨, returns 1 if equivalent
   and 0 otherwise.
 Note: see related function ≢ (Not Match)
       always returns the same result as = (Equals) when 𝕩 and 𝕨 are atoms.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ≡ 'a'
    0
@@ -628,9 +629,9 @@ Note: see related function ≢ (Not Match)
 at \"abc\" = \"ab\"
          ^
 "])
-                 ("≢" .
-                  ["Monad: Shape | Dyad: Not Match | Input: \\M"
-                   "≢ is a function.
+                   ("≢" .
+                    ["Monad: Shape | Dyad: Not Match | Input: \\M"
+                     "≢ is a function.
 - Its monadic form returns the shape of its input. The shape is a list of
   natural numbers.
 - Its dyadic form tests in-equivalency between 𝕩 and 𝕨, returns 0 if equivalent
@@ -640,7 +641,7 @@ Note: = (Rank) and ≠ (Length) can be derived from ≢ (Shape).
       Length can be defined as a fold: 1⊣´≢
       See related function ⥊ (Reshape)
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ## Make a 4-dimensional array of length 1, rank 4
 ## The only element is an array of shape 3‿2‿6, i.e., an array with 3-elements
@@ -682,13 +683,13 @@ Note: = (Rank) and ≠ (Length) can be derived from ≢ (Shape).
 at \"abc\" = \"ab\"
          ^
 "])
-                 ("⊣" .
-                  ["Monad: Identity | Dyad: Left | Input: \\{"
-                   "⊣ is a function.
+                   ("⊣" .
+                    ["Monad: Identity | Dyad: Left | Input: \\{"
+                     "⊣ is a function.
 - Its monadic form returns its input.
 - Its dyadic form returns 𝕨.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⊣ 1
    1
@@ -741,13 +742,13 @@ a ← \"hello I'm a\"
 a ⌽∘⊣↩ @
    \"a m'I olleh\"
 "])
-                 ("⊢" .
-                  ["Monad: Identity | Dyad: Right | Input: \\}"
-                   "⊢ is a function.
+                   ("⊢" .
+                    ["Monad: Identity | Dyad: Right | Input: \\}"
+                     "⊢ is a function.
 - Its monadic form returns its input.
 - Its dyadic form returns 𝕩 (its right argument).
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⊢ 1
    1
@@ -779,9 +780,9 @@ a ⌽∘⊣↩ @
 ÷⟜2⍟3 24
    3
 "])
-                 ("⥊" .
-                  ["Monad: Deshape | Dyad: Reshape | Input: \\z"
-                   "⥊ is a function.
+                   ("⥊" .
+                    ["Monad: Deshape | Dyad: Reshape | Input: \\z"
+                     "⥊ is a function.
 - Its monadic form removes all shape information from its input. Returning a
   list of all elements from the array in reading order.
 - Its dyadic form ignores the shape information of 𝕩 and adds shape information
@@ -795,7 +796,7 @@ Note: in its dyadic form, one entry of 𝕨 may be left for BQN to fill in.
         reused cyclically.
       see related function ≍ (Solo).
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ## Deshape returns a list in reading order: left to right, top to bottom.
 ⊢ a ← +⌜´ ⟨100‿200, 30‿40, 5‿6‿7⟩
@@ -902,14 +903,14 @@ at 2‿∘ ⥊ \"abcde\"
      de \"
          ┘
 "])
-                 ("∾" .
-                  ["Monad: Join | Dyad: Join to | Input: \,"
-                   "∾ is a function.
+                   ("∾" .
+                    ["Monad: Join | Dyad: Join to | Input: \,"
+                     "∾ is a function.
 - Its monadic form concatenates the elements of its input.
 - Its dyadic form returns an array whose major cells are the major cells from
   𝕨 followed by the major cells of 𝕩.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ∾ \"time\"‿\"to\"‿\"join\"‿\"some\"‿\"words\"
    \"timetojoinsomewords\"
@@ -1023,13 +1024,13 @@ at a ∾ 2‿5⥊b  # Shapes don't fit
      2 3 4 5
              ┘
 "])
-                 ("𝕩" .
-                  ["Right argument of a block or function | Input: \\x or \\X"
-                   "𝕩 and 𝕏 are reserved names.
+                   ("𝕩" .
+                    ["Right argument of a block or function | Input: \\x or \\X"
+                     "𝕩 and 𝕏 are reserved names.
 - It always refers to the right argument of a function.
 - See related form, 𝕨 (left argument).
 "
-                   "Examples:
+                     "Examples:
 ## Use in a block
 {𝕩+1} 2
    3
@@ -1044,13 +1045,13 @@ F ← {𝕩 × 𝕩}
 F 2
    4
 "])
-                 ("𝕏" .
-                  ["Right argument of a block or function | Input: \\x or \\X"
-                   "𝕩 and 𝕏 are reserved names.
+                   ("𝕏" .
+                    ["Right argument of a block or function | Input: \\x or \\X"
+                     "𝕩 and 𝕏 are reserved names.
 - It always refers to the right argument of a function.
 - See related form, 𝕨 (left argument).
 "
-                   "Examples:
+                     "Examples:
 ## Use in a block
 {𝕩+1} 2
    3
@@ -1070,15 +1071,15 @@ F 2
 
 
 
-                 ("𝕨" .
-                  ["Left argument of a block or function | Input: \\w or \\W"
-                   "𝕨 and 𝕎 are reserved names.
+                   ("𝕨" .
+                    ["Left argument of a block or function | Input: \\w or \\W"
+                     "𝕨 and 𝕎 are reserved names.
 It always refers to the left argument of a function.
 See related form, 𝕩 (right argument).
 "
 
 
-                   "Examples:
+                     "Examples:
 ## Use in a block
 'c' {𝕨=𝕩} \"abcd\"
    ⟨ 0 0 1 0 ⟩
@@ -1100,15 +1101,15 @@ See related form, 𝕩 (right argument).
 
 
 
-                 ("𝕎" .
-                  ["Left argument of a block or function | Input: \\w or \\W"
+                   ("𝕎" .
+                    ["Left argument of a block or function | Input: \\w or \\W"
 
-                   "𝕨 and 𝕎 is a reserved name.
+                     "𝕨 and 𝕎 is a reserved name.
   It always refers to the left argument of a function.
   See related form, 𝕩 (right argument)."
 
 
-                   "Examples:
+                     "Examples:
 ## Use in a block
 'c' {𝕨=𝕩} \"abcd\"
    ⟨ 0 0 1 0 ⟩
@@ -1130,10 +1131,10 @@ See related form, 𝕩 (right argument).
 
 
 
-                 ("≍" .
-                  ["Monad: Solo | Dyad: Couple | Input: \\."
+                   ("≍" .
+                    ["Monad: Solo | Dyad: Couple | Input: \\."
 
-                   "≍ is a function.
+                     "≍ is a function.
   Its monadic form returns an array with its input as the only major cell.
   Its dyadic form returns an array with elements 𝕩 and 𝕨, and outer axis of
     length-2
@@ -1142,7 +1143,7 @@ See related form, 𝕩 (right argument).
   Note: ≍ ←→ >{⟨𝕩⟩;⟨𝕨,𝕩⟩} or in other words: Solo is {>⟨𝕩⟩}, Couple is {>⟨𝕨,𝕩⟩}"
 
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ## Notice that ≍ always adds an axis, thus applied to unit values returns a list
 ≍ 2
@@ -1187,10 +1188,10 @@ p ≍ q   # p coupled to q
 
 
 
-                 ("⋈" .
-                  ["Monad: Enlist | Dyad: Pair | Input: \\Z"
+                   ("⋈" .
+                    ["Monad: Enlist | Dyad: Pair | Input: \\Z"
 
-                   "⋈ is a function.
+                     "⋈ is a function.
   Its monadic form returns a singleton list containing its input.
   Its dyadic form a list containing both 𝕨 and 𝕩.
   See related form, > (Merge).
@@ -1198,7 +1199,7 @@ p ≍ q   # p coupled to q
   Note: ⋈ ←→ ≍○<, and ≍ ←→ >∘⋈"
 
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⋈ \"enlist\"    # ⟨𝕩⟩
    ⟨ \"enlist\" ⟩
@@ -1235,10 +1236,10 @@ p ≍ q   # p coupled to q
 
 
 
-                 ("↑" .
-                  ["Monad: Prefixes | Dyad: Take | Input: \\r"
+                   ("↑" .
+                    ["Monad: Prefixes | Dyad: Take | Input: \\r"
 
-                   "↑ is a function.
+                     "↑ is a function.
   Its monadic form returns a list of all prefixes of its argument along the
     first axis.
   Its dyadic form returns the first 𝕨 elements of 𝕩.
@@ -1252,7 +1253,7 @@ p ≍ q   # p coupled to q
         See related form, ↓ (Drop)."
 
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ↑ \"hello\"              # notice the empty array and input is in the result
    ⟨ ⟨⟩ \"h\" \"he\" \"hel\" \"hell\" \"hello\" ⟩
@@ -1321,10 +1322,10 @@ p ≍ q   # p coupled to q
 
 
 
-                 ("↓" .
-                  ["Monad: Suffixes | Dyad: Drop | Input: \\c"
+                   ("↓" .
+                    ["Monad: Suffixes | Dyad: Drop | Input: \\c"
 
-                   "↓ is a function.
+                     "↓ is a function.
   Its monadic form returns a list of all suffixes of its argument along the
     first axis.
   Its dyadic form drops the first 𝕨 elements of 𝕩 and returns the rest.
@@ -1337,7 +1338,7 @@ p ≍ q   # p coupled to q
         See related form, ↑ (Take)."
 
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ↓ \"hello\"                # notice the empty array and input is in the result
    ⟨ \"hello\" \"ello\" \"llo\" \"lo\" \"o\" ⟨⟩ ⟩
@@ -1397,10 +1398,10 @@ p ≍ q   # p coupled to q
 
 
 
-                 ("↕" .
-                  ["Monad: Range | Dyad: Windows | Input: \\d"
+                   ("↕" .
+                    ["Monad: Range | Dyad: Windows | Input: \\d"
 
-                   "↕ is a function.
+                     "↕ is a function.
   Its monadic form returns an array where each element's value is its own index.
   Its dyadic form returns ≠𝕩 contiguous slices of 𝕩 that are of length 𝕨.
   Note: (Range) the result always has depth (≡) one more than the argument.
@@ -1408,7 +1409,7 @@ p ≍ q   # p coupled to q
         (Window) slices always have the same rank as the argument array (𝕩)"
 
 
-                   "Examples:
+                     "Examples:
 ## Monadic form, all results are length 6, but elements differ
 ## 𝕩 must be a natural number, notice the result is ≠𝕩, but 𝕩 is not in the result
 ↕6
@@ -1531,10 +1532,10 @@ b × ↕≠b                      # now multiply with b
 
 
 
-                 ("»" .
-                  ["Monad: Nudge | Dyad: Shift Before | Input: \\L"
+                   ("»" .
+                    ["Monad: Nudge | Dyad: Shift Before | Input: \\L"
 
-                   "» is a function.
+                     "» is a function.
   Its monadic form returns its input where each element has shifted one major
     cell to the right, and the new cell is filled with 0s or \" \".
   Its dyadic form adds 𝕨 to the beginning of 𝕩, while maintiaing the length of 𝕩.
@@ -1546,7 +1547,7 @@ b × ↕≠b                      # now multiply with b
         Shift Before is defined as {(≠𝕩)↑𝕨∾𝕩}
         See related form, « (Nudge Back/Shift After)"
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 » \"abc\"
    \" ab\"    # notice that the length of the result equals the length of 𝕩
@@ -1642,10 +1643,10 @@ s ≍ »s
 
 
 
-                 ("«" .
-                  ["Monad: Nudge Back | Dyad: Shift After | Input: \\H"
+                   ("«" .
+                    ["Monad: Nudge Back | Dyad: Shift After | Input: \\H"
 
-                   "« is a function.
+                     "« is a function.
   Its monadic form returns its input where each element has shifted one major
     cell to the left, and the new cell is filled with 0s or \" \".
   Its dyadic form adds 𝕨 to the end of 𝕩, while maintaining the length of 𝕩.
@@ -1657,7 +1658,7 @@ s ≍ »s
         Shift After is defined as {(-≠𝕩)↑𝕩∾𝕨}
         See related form, » (Nudge/Shift Before)"
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 « \"abc\"
    \"bc \"    # notice that the length of the result equals the length of 𝕩
@@ -1758,10 +1759,10 @@ s ≍ «s
 
 
 
-                 ("⌽" .
-                  ["Monad: Reverse | Dyad: Rotate | Input: \\q"
+                   ("⌽" .
+                    ["Monad: Reverse | Dyad: Rotate | Input: \\q"
 
-                   "⌽ is a function.
+                     "⌽ is a function.
   Its monadic form returns an array whose major cells are reverse from the input.
   Its dyadic form cycles or rotates the major cells in 𝕩, according to 𝕨.
   Note: Both Reverse and Rotate return an array with the same shape and elements
@@ -1769,7 +1770,7 @@ s ≍ «s
         Avoid Rotate if there is no reason to treat data in 𝕩 as cyclic or
           periodic."
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⌽ \"abcdefg\"
    \"gfedcba\"
@@ -1892,10 +1893,10 @@ at 3‿4‿2 ⌽ \"just a list\"
 
 
 
-                 ("⍉" .
-                  ["Monad: Transpose | Dyad: Reorder axes | Input: \\a"
+                   ("⍉" .
+                    ["Monad: Transpose | Dyad: Reorder axes | Input: \\a"
 
-                   "⍉ is a function.
+                     "⍉ is a function.
   Its monadic form returns an array whose first axis has been moved to the end.
   Its dyadic form generalizes the monadic form for arbritrary arrangement of 𝕩,
     according to 𝕨.
@@ -1906,7 +1907,7 @@ at 3‿4‿2 ⌽ \"just a list\"
                        Invariant: ∧´𝕨<r
         see related function, ⌽ (Rotate)"
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ## mat is a 2‿3 matrix
 ⊢ mat ← 2‿3 ⥊ ↕6
@@ -2004,10 +2005,10 @@ a322 ← 3‿2‿2⥊↕12
 
 
 
-                 ("/" .
-                  ["Monad: Indices | Dyad: Replicate | Input: \/"
+                   ("/" .
+                    ["Monad: Indices | Dyad: Replicate | Input: \/"
 
-                   "/ is a function.
+                     "/ is a function.
   Its monadic form returns a list of natural numbers that are the indices of 𝕩.
   Its dyadic form repeats each major cell of 𝕩, the corresponding 𝕨 times.
   Note: (Replicate) Invariant: (𝕨≠) ≡ (𝕩≠)
@@ -2017,7 +2018,7 @@ a322 ← 3‿2‿2⥊↕12
 
         (Indices) 𝕩 must be a list of natural numbers, then /𝕩 is 𝕩/↕≠𝕩"
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 / 3‿0‿1‿2
    ⟨ 0 0 0 2 3 3 ⟩
@@ -2166,10 +2167,10 @@ b ≡ ⟨⟩ / b
 
 
 
-                 ("⍋" .
-                  ["Monad: Grade Up | Dyad: Bins Up | Input: \\T"
+                   ("⍋" .
+                    ["Monad: Grade Up | Dyad: Bins Up | Input: \\T"
 
-                   "⍋ is a function.
+                     "⍋ is a function.
   Its monadic form returns a list of natural numbers that are an ascending ording
     of the input.
   Its dyadic form returns a list of natural numbers, where each number indicates
@@ -2178,7 +2179,7 @@ b ≡ ⟨⟩ / b
                   Result is always in ascending sorted order.
         see related function, ⍒ (Grade Down/Bins Down)"
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⊢ l ← \"planet\"‿\"moon\"‿\"star\"‿\"asteroid\"
    ⟨ \"planet\" \"moon\" \"star\" \"asteroid\" ⟩
@@ -2220,10 +2221,10 @@ other_scores ⍋ scores
 
 
 
-                 ("⍒" .
-                  ["Monad: Grade Down | Dyad: Bins Down | Input: \\V"
+                   ("⍒" .
+                    ["Monad: Grade Down | Dyad: Bins Down | Input: \\V"
 
-                   "⍒ is a function.
+                     "⍒ is a function.
   Its monadic form returns a list of natural numbers that are a descending ording
     of the input.
   Its dyadic form returns a list of natural numbers, where each number indicates
@@ -2232,7 +2233,7 @@ other_scores ⍋ scores
                   Result is always in descending sorted order.
         see related function, ⍒ (Grade Down/Bins Down)"
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⊢ l ← \"planet\"‿\"moon\"‿\"star\"‿\"asteroid\"
    ⟨ \"planet\" \"moon\" \"star\" \"asteroid\" ⟩
@@ -2274,10 +2275,10 @@ other_scores ⍒ scores
 
 
 
-                 ("⊏" .
-                  ["Monad: First Cell | Dyad: Select | Input: \\i"
+                   ("⊏" .
+                    ["Monad: First Cell | Dyad: Select | Input: \\i"
 
-                   "⊏ is a function.
+                     "⊏ is a function.
   Its monadic form returns the major cell of 𝕩 at index 0.
   Its dyadic form reorganizes 𝕩 along one or more axes according to the indices
     given by 𝕨.
@@ -2292,7 +2293,7 @@ other_scores ⍒ scores
         see related function, ⊑ (Pick)"
 
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⊏ \"abc\"
    ┌·
@@ -2407,9 +2408,9 @@ at ⊏ 'a'
 
 
 
-                 ("⊑" .
-                  ["Monad: First | Dyad: Pick | Input: \\I"
-                   "⊑ is a function.
+                   ("⊑" .
+                    ["Monad: First | Dyad: Pick | Input: \\I"
+                     "⊑ is a function.
 - Its monadic form returns the first element of 𝕩 in index order.
 - Its dyadic form returns elements from 𝕩 based on index lists from 𝕨.
 Note: (First) is Pick where 𝕨 is 0¨≢𝕩
@@ -2422,7 +2423,7 @@ Note: (First) is Pick where 𝕨 is 0¨≢𝕩
       see related function, ⊐ (Classify)
 "
 
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⊑ 'a'
    'a'
@@ -2533,9 +2534,9 @@ at ⟨⟨2,3⟩,1⟩ ⊑ a
          ┘
                  ┘
 "])
-                 ("⊐" .
-                  ["Monad: Classify | Dyad: Index of | Input: \\o"
-                   "⊐ is a function.
+                   ("⊐" .
+                    ["Monad: Classify | Dyad: Index of | Input: \\o"
+                     "⊐ is a function.
 - Its monadic form returns a list of natural numbers, where each number
   corresponds to the index of first appearance of the corresponding value in 𝕩.
 - Its dyadic form returns a list of indices, where each index is the first
@@ -2544,7 +2545,7 @@ Note: (Classify) is idempotent.
         see related function, ⍷ (Deduplicate)
         see related function, ⊒ (Occurence Count)
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 # notice that 5 is at index 0, and so 0's are in 5's position in the result
 ⊐ 5‿6‿2‿2‿5‿1
@@ -2594,9 +2595,9 @@ Note: (Classify) is idempotent.
 \"zero\"‿\"one\"‿\"two\"‿\"three\" ⊐ \"one\"‿\"eight\"‿\"two\"
    ⟨ 1 4 2 ⟩
 "])
-                 ("⊒" .
-                  ["Monad: Occurrence Count | Dyad: Progressive Index of | Input: \\O"
-                   "⊒ is a function.
+                   ("⊒" .
+                    ["Monad: Occurrence Count | Dyad: Progressive Index of | Input: \\O"
+                     "⊒ is a function.
 - Its monadic form returns a list of natural numbers, where each number is the
   number of previous cells that match the current cell.
 - Its dyadic form returns a list of indices, where each index is either the
@@ -2607,7 +2608,7 @@ Note: (Progressive Index of)
          use ⊒˜<≠∘⊢ for Progressive Membership of
          ⊒˜ is the same as ↕∘≠
       see related function, ⊐ (Classify)"
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⊒   2‿7‿1‿8‿1‿7‿1‿8‿2‿8‿4
    ⟨ 0 0 0 0 1 1 2 1 1 2 0 ⟩    # notice a 1 at the next occurrence of 1 in 𝕩
@@ -2645,16 +2646,16 @@ Note: (Progressive Index of)
 \"aaabb\" ⊒ \"ababababab\"
    ⟨ 0 3 1 4 2 5 5 5 5 5 ⟩
 "])
-                 ("∊" .
-                  ["Monad: Mark Firsts | Dyad: Member of | Input: \\e"
-                   "∊ is a function.
+                   ("∊" .
+                    ["Monad: Mark Firsts | Dyad: Member of | Input: \\e"
+                     "∊ is a function.
 - Its monadic form returns a list of booleans, where each number is either a 0,
   if the major cell of 𝕩 is a duplicate of a previous cell, or 1 otherwise.
 - Its dyadic form returns a list of numbers of length ≠𝕨, each number is either
   a 0 or 1. A 1 indicates an entry of 𝕨 matches some entry in 𝕩, a 0 otherwise.
 Note: see related function, ⍷ (Deduplicate)
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ∊   3‿1‿4‿1‿5‿9‿2‿6‿5
    ⟨ 1 1 1 0 1 1 1 1 0 ⟩     # notice the first duplicate 1, corresponds to a 0
@@ -2697,9 +2698,9 @@ Note: see related function, ⍷ (Deduplicate)
 \"initial set\" (¬∘∊/⊣) \"difference\"  # Remove 𝕩
    \"tal st\"
 "])
-                 ("⍷" .
-                  ["Monad: Deduplicate | Dyad: Find | Input: \\E"
-                   "⍷ is a function.
+                   ("⍷" .
+                    ["Monad: Deduplicate | Dyad: Find | Input: \\E"
+                     "⍷ is a function.
 - Its monadic form removes every major cell that matches an earlier cell.
 - Its dyadic form searches for occurrences of an array 𝕨, in 𝕩. The result is a
   list of booleans for each possible location.
@@ -2711,7 +2712,7 @@ Note: (Deduplicate)
          there is no guarantee the result maintains the shape of 𝕩
          if ≠𝕨 > ≠𝕩 then the result is empty
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⍷ >\"take\"‿\"drop\"‿\"drop\"‿\"pick\"‿\"take\"‿\"take\"
    ┌─
@@ -2809,15 +2810,15 @@ at 9 ↕ \"short\"
      1 0 1 0 1 0
                  ┘
 "])
-                 ("⊔" .
-                  ["Monad: Group Indices | Dyad: Group | Input: \\u"
-                   "⊔ is a function.
+                   ("⊔" .
+                    ["Monad: Group Indices | Dyad: Group | Input: \\u"
+                     "⊔ is a function.
 - Its monadic form returns a list of lists of indices, where each sublist
   contains indices of equal elements of 𝕩.
 - Its dyadic form returns a list of groups, each containing cells from 𝕩,
   according to a list of atomic indices in 𝕨.
 Note: (Group) 𝕨 and 𝕩 must have the same length"
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ⊔ 0‿2‿5‿3‿2
    ⟨ ⟨ 0 ⟩ ⟨⟩ ⟨ 1 4 ⟩ ⟨ 3 ⟩ ⟨⟩ ⟨ 2 ⟩ ⟩     # 2 is at index 1 and 4, 3 is unique hence ⟨⟩
@@ -2919,16 +2920,16 @@ countries ≍˘ co countries⊸(⊐∾≠∘⊣)⊸⊔ ln
      \"US\" ⟨ \"Phelps\" ⟩
                                      ┘
 "])
-                 ("!" .
-                  ["Monad: Assert | Dyad: Assert with message | Input: !"
-                   "! is a function.
+                   ("!" .
+                    ["Monad: Assert | Dyad: Assert with message | Input: !"
+                     "! is a function.
 - Its monadic form tests that 𝕩 is 1,
   - if it is then it returns 𝕩
   - otherwise it throws an Error.
 - Its dyadic form returns a message with the error thrown.
 - Note: (Assert) the right argument must be exactly 1, or 0.
 "
-                   "Examples:
+                     "Examples:
 ## Monadic form
 ! 2=2  # Passed
    1
@@ -2964,10 +2965,10 @@ at MyError ← {𝕨 \"My custom error\"⊸!⍟(1⊸≢) 𝕩}
 at \"hello\" MyError 0
            ^^^^^^^
 "])))
-        (ht (make-hash-table :test 'equal)))
-    (dolist (entry table)
-      (puthash (car entry) (cdr entry) ht))
-    ht)
+          (ht (make-hash-table :test 'equal)))
+      (dolist (entry table)
+        (puthash (car entry) (cdr entry) ht))
+      ht))
   "This table associates BQN symbols as hash-keys to a 3-vector of docstrings.
 Position 0 is short description for eldoc, position 1 is a long description,
 and position 2 is any extra description.")

--- a/bqn-symbols-doc.el
+++ b/bqn-symbols-doc.el
@@ -18,8 +18,6 @@
 ;;
 ;;; Code:
 
-(require 'subr-x)
-
 ;; Arrays and hashes are not very Lispy, however they will be employed here
 ;; because we want the lowest latency latency possible for a user-facing
 ;; structure. For all intents and purposes, this table should be regarded as

--- a/bqn-symbols-doc.el
+++ b/bqn-symbols-doc.el
@@ -19,9 +19,9 @@
 ;;; Code:
 
 ;; Arrays and hashes are not very Lispy, however they will be employed here
-;; because we want the lowest latency latency possible for a user-facing
+;; because we want the lowest latency latency possible for an end-user-facing
 ;; structure. For all intents and purposes, this table should be regarded as
-;; read-only.
+;; read-only; indeed, it is "cached" at byte-compile time via eval-when-compile
 (defconst bqn-symbols-doc--symbol-doc-table
   #s(hash-table
      size 85 ;; set to number of symbols in bqn-symbols.el

--- a/bqn-symbols-doc.el
+++ b/bqn-symbols-doc.el
@@ -23,32 +23,26 @@
 ;; structure. For all intents and purposes, this table should be regarded as
 ;; read-only; indeed, it is "cached" at byte-compile time via eval-when-compile
 (defconst bqn-symbols-doc--symbol-doc-table
-  #s(hash-table
-     size 85 ;; set to number of symbols in bqn-symbols.el
-     test equal
-     data
-     (;; Each entry is:
-      ;; <symbol> [short-description long-description extra-description]
-      ;; short-description should be <= 80 characters to fit on modeline
-      ;; long-description should state what symbol is and what forms symbol has
-      ;; extra-description should provide minimal examples
-      ;; The indentation is purposefully strange for doc string presentation
-      ;; ================================================
-      ;; Arithmetic
-      ;; Addition
-
-      "+"
-
-      ["Monad: Conjugate | Dyad: Addition | Input: +"
-
-       "+ is a function.
-  Its monadic form conjugates.
-  Its dyadic form is addition.
-  Can be applied to numbers, arrays and characters. For characters, uses an
-    affine space relative to the linear space of numbers. Thus, 'a' + 2 is valid
-    but 'a' + 'b' is not."
-
-       "Examples:
+  (let ((table '(
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; The format of each entry follows the model below
+;;; (<symb> . [short-description long-description extra-examples])
+;;; where:
+;;; - <symb> is the symbol to be described
+;;; - short-description should be no more than 80 characters (to fit modeline)
+;;; - long-description should state what symbol is and what forms symbol has
+;;; - extra-examples should provide minimal examples
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+                 ("+" .
+                  ["Monad: Conjugate | Dyad: Addition | Input: +"
+                   "+ is a function.
+- Its monadic form conjugates.
+- Its dyadic form is addition.
+- Can be applied to numbers, arrays and characters. For characters, uses an
+affine space relative to the linear space of numbers. Thus, 'a' + 2 is valid but
+'a' + 'b' is not.
+"
+                   "Examples:
 ## Monadic form
 NOTE: Not implemented yet.
 
@@ -65,21 +59,16 @@ NOTE: Not implemented yet.
 'a' + 'b'
    Error: +: Unexpected argument types
    at 'a' + 'b'
-          ^"]
-
-      ;; ================================================
-      ;; Subtraction
-
-      "-"
-
-      ["Monad: Negation | Dyad: Subtraction | Input: -"
-
-       "- is a function.
-  Its monadic form negates
-  Its dyadic form subtracts
-  Can be applied to characters"
-
-       "Examples:
+          ^
+"])
+                 ("-" .
+                  ["Monad: Negation | Dyad: Subtraction | Input: -"
+                   "- is a function.
+- Its monadic form negates.
+- Its dyadic form subtracts.
+Can be applied to characters.
+"
+                   "Examples:
 ## Monadic form
 -0
    ¯0
@@ -89,7 +78,6 @@ NOTE: Not implemented yet.
    1
 - 1‿2‿3
    ⟨ ¯1 ¯2 ¯3 ⟩
-
 
 ## Dyadic form
 0 - 1
@@ -109,23 +97,17 @@ NOTE: Not implemented yet.
 
 'c' - \"abc\"
    ⟨ 2 1 0 ⟩
-"]
-
-      ;; ================================================
-      ;; Multiplication
-
-      "×"
-
-      ["Monad: Sign | Dyad: Multiplication | Input: \\="
-
-       "× is a function.
-  Its monadic form returns the sign of its argument:
-    no sign        =>  0
-    positive sign  =>  1
-    negative sign  =>  ¯1
-  Its dyadic form multiplies."
-
-       "Examples:
+"])
+                 ("×" .
+                  ["Monad: Sign | Dyad: Multiplication | Input: \\="
+                   "× is a function.
+- Its monadic form returns the sign of its argument:
+  -  no sign (zero) =>  0
+  -  positive sign  =>  1
+  -  negative sign  =>  ¯1
+-Its dyadic form multiplies.
+"
+                   "Examples:
 ## Monadic form
 × 0
   0
@@ -152,8 +134,6 @@ NOTE: Not implemented yet.
 
    2‿3‿4 × 5‿6
          ^
-
-
 Note:
   To compute a logarithm use Undo: ⋆⁼ (\\+\\3):
     # base is e in monadic form
@@ -162,20 +142,16 @@ Note:
 
     # 𝕨 is base in dyadic form
     2 ⋆⁼ 1024 => 10
-    10 ⋆⁼ 100 => 2 "]
+    10 ⋆⁼ 100 => 2
+"])
+                 ("÷" .
+                  ["Monad: Reciprocal | Dyad: Divide | Input: \\-"
+                   "÷ is a function.
+- Its monadic form computes 1÷x, where x is ÷'s argument.
+- Its dyadic form is division.
+"
 
-      ;; ================================================
-      ;; Division
-
-      "÷"
-
-      ["Monad: Reciprocal | Dyad: Divide | Input: \\-"
-
-       "÷ is a function.
-  Its monadic form computes 1÷x, where x is ÷'s argument
-  Its dyadic form is division"
-
-       "Examples:
+                   "Examples:
 ## Monadic form
 ÷ 0
   ∞
@@ -198,20 +174,15 @@ Note:
    Mapping: Equal-rank argument shapes don't agree
 
    1‿2‿3 ÷ 1‿2
-         ^ "]
-
-      ;; ================================================
-      ;; Exponentiation
-
-      "⋆"
-
-      ["Monad: Exponential | Dyad: Power | Input: \\+"
-
-       "⋆ is a function.
-  Its monadic form raises its argument to euler's number.
-  Its dyadic form raises 𝕨 to 𝕩."
-
-       "Examples:
+         ^
+"])
+                 ("⋆" .
+                  ["Monad: Exponential | Dyad: Power | Input: \\+"
+                   "⋆ is a function.
+- Its monadic form raises its argument to euler's number.
+- Its dyadic form raises 𝕨 to 𝕩.
+"
+                   "Examples:
 ## Monadic form
 ⋆ 0
    1
@@ -237,20 +208,15 @@ Note:
    Mapping: Equal-rank argument shapes don't agree
 
    0‿1‿2 ⋆ 2‿3‿4‿5
-         ^ "]
-
-      ;; ================================================
-      ;; Root
-
-      "√"
-
-      ["Monad: Square Root | Dyad: Root | Input: \\_"
-
-       "√ is a function.
-  Its monadic form computes the square root of its argument.
-  Its dyadic form computes the root of 𝕩 with the degree 𝕨."
-
-       "Examples:
+         ^
+"])
+                 ("√" .
+                  ["Monad: Square Root | Dyad: Root | Input: \\_"
+                   "√ is a function.
+- Its monadic form computes the square root of its argument.
+- Its dyadic form computes the root of 𝕩 with the degree 𝕨.
+"
+                   "Examples:
 ## Monadic form
 √4
    2
@@ -265,27 +231,20 @@ Note:
 
 ¯0‿0‿¯2‿2‿¯2 √ 1‿¯1‿¯1‿4‿4
    ⟨ 1 1 NaN 2 0.5 ⟩
-          "]
-
-      ;; ================================================
-      ;; Floor
-
-      "⌊"
-
-      ["Monad: Floor | Dyad: Minimum | Input: \\b"
-
-       "⌊ is a function.
-  Its monadic form returns the floor of its argument.
-  Its dyadic form returns the minimum of its arguments."
-
-       "Examples:
+"])
+                 ("⌊" .
+                  ["Monad: Floor | Dyad: Minimum | Input: \\b"
+                   "⌊ is a function.
+- Its monadic form returns the floor of its argument.
+- Its dyadic form returns the minimum of its arguments.
+"
+                   "Examples:
 ## Monadic form
 ⌊ π
    3
 
 ⌊ 2.71827
    2
-
 
 ## Dyadic form
 0‿1‿2‿3‿4 ⌊ 4‿3‿2‿1‿0
@@ -294,30 +253,22 @@ Note:
 0‿¯1‿¯2‿¯3‿¯4 ⌊ 4‿3‿2‿1‿0
    ⟨ 0 ¯1 ¯2 ¯3 ¯4 ⟩
 
-
 Note:
   To take a minimum of an entire list, use the fold: ⌊´ (\\b\\5)
-          "]
-
-      ;; ================================================
-      ;; Ceiling
-
-      "⌈"
-
-      ["Monad: Ceiling | Dyad: Maximum | Input: \\B"
-
-       "⌈ is a function.
-  Its monadic form returns the ceiling of its argument.
-  Its dyadic form returns the maximum of its arguments."
-
-       "Examples:
+"])
+                 ("⌈" .
+                  ["Monad: Ceiling | Dyad: Maximum | Input: \\B"
+                   "⌈ is a function.
+- Its monadic form returns the ceiling of its argument.
+- Its dyadic form returns the maximum of its arguments.
+"
+                   "Examples:
 ## Monadic form
  ⌈ π
    4
 
  ⌈ 2.71827
    3
-
 
 ## Dyadic form
 0‿1‿2‿3‿4 ⌈ 4‿3‿2‿1‿0
@@ -326,22 +277,16 @@ Note:
 0‿¯1‿¯2‿¯3‿¯4 ⌈ 4‿3‿2‿1‿0
    ⟨ 4 3 2 1 0 ⟩
 
-
 Note:
-  To take a maximum of an entire list, use the fold: ⌈´ (\\B\\5)"]
-
-      ;; ================================================
-      ;; Absolute value
-
-      "|"
-
-      ["Monad: Absolute Value | Dyad: Modulus | Input: |"
-
-       "| is a function.
-  Its monadic form returns the absolute value of its argument.
-  Its dyadic form returns the remainder resulting from division of 𝕩 by 𝕨."
-
-       "Examples:
+  To take a maximum of an entire list, use the fold: ⌈´ (\\B\\5)
+"])
+                 ("|" .
+                  ["Monad: Absolute Value | Dyad: Modulus | Input: |"
+                   "| is a function.
+- Its monadic form returns the absolute value of its argument.
+- Its dyadic form returns the remainder resulting from division of 𝕩 by 𝕨.
+"
+                   "Examples:
 ## Monadic form
 | ¯1
    1
@@ -361,25 +306,21 @@ Note:
    0
 
 0 | ∞
-   NaN "]
-
-      ;; ================================================
-      ;; Comparisons
-      ;; Equality
-"="
-
-["Monad: Rank | Dyad: Equals | Input: ="
-
- "= is a function.
-  Its monadic form returns the rank of its input.
-  Its dyadic form tests for atomic equality of its arguments:
-    Found to be equal     => 1
-    Not found to be equal => 0
-  Note: values of different types can never be equal.
-        characters are equal if they have the same code point (i.e c - @, where c is the char)."
-
- "Examples:
-
+   NaN
+"])
+                 ("=" .
+                  ["Monad: Rank | Dyad: Equals | Input: ="
+                   "= is a function.
+- Its monadic form returns the rank of its input.
+- Its dyadic form tests for atomic equality of its arguments:
+  - Found to be equal     => 1
+  - Not found to be equal => 0
+Note:
+- values of different types can never be equal.
+- characters are equal if they have the same code point (i.e c - @, where c is
+  the char).
+"
+                   "Examples:
 ## Monadic form
 = 'a'
    0
@@ -400,23 +341,18 @@ Note:
 
 Even ← 0=2|⊣
 Even ↕10
-   ⟨ 1 0 1 0 1 0 1 0 1 0 ⟩"]
-
-      ;; ================================================
-      ;; Inequality
-"≠"
-
-["Monad: Length | Dyad: Not Equals | Input: \\\/"
-
- "≠ is a function.
-  Its monadic form returns the length of its input.
-  Its dyadic form tests for atomic inequality of its arguments:
-    Found to be not equal     => 1
-    Not found to be not equal => 0
-  Note: values of different types can never be equal."
-
- "Examples:
-
+   ⟨ 1 0 1 0 1 0 1 0 1 0 ⟩
+"])
+                 ("≠" .
+                  ["Monad: Length | Dyad: Not Equals | Input: \\\/"
+                   "≠ is a function.
+- Its monadic form returns the length of its input.
+- Its dyadic form tests for atomic inequality of its arguments:
+  - Found to be not equal     => 1
+  - Not found to be not equal => 0
+Note: values of different types can never be equal.
+"
+                   "Examples:
 ## Monadic form
 ≠ 'a'
    1
@@ -430,47 +366,32 @@ Even ↕10
 
 ## Dyadic form
 'b' ≠ \"abacba\"
-   ⟨ 1 0 1 1 0 1 ⟩"]
-
-      ;; ================================================
-      ;; Less than or equal
-"≤"
-
-["Dyad: Less than or equal | Input: \\<"
-
- "≤ is a function.
-  It has no monadic form.
-  Its dyadic form tests for less than or equal to:
-  "
-
- ""]
-
-      ;; ================================================
-      ;; Greater than or equal
-"≥"
-
-["Dyad: Greater than or equal | Input: \\>"
-
- "≥ is a function.
-  It has no monadic form.
-  Its dyadic form tests for greater than or equal to:
-  "
-
- ""]
-
-      ;; ================================================
-      ;; less than
-"<"
-
-["Monad: Enclose | Dyad: Less than | Input: <"
-
- "< is a function.
-  It monadic form returns its argument in a unit array.
-  Its dyadic form returns the result comparing 𝕨 with 𝕩.
-  Note: characters are always considered greater than numbers, even ∞"
-
- "Examples:
-
+   ⟨ 1 0 1 1 0 1 ⟩
+"])
+                 ("≤" .
+                  ["Dyad: Less than or equal | Input: \\<"
+                   "≤ is a function.
+- It has no monadic form.
+- Its dyadic form tests for less than or equal to:
+"
+                   "Examples:
+"])
+                 ("≥" .
+                  ["Dyad: Greater than or equal | Input: \\>"
+                   "≥ is a function.
+- It has no monadic form.
+- Its dyadic form tests for greater than or equal to.
+"
+                   "Examples
+"])
+                 ("<" .
+                  ["Monad: Enclose | Dyad: Less than | Input: <"
+                   "< is a function.
+- Its monadic form returns its argument in a unit array.
+- Its dyadic form returns the result comparing 𝕨 with 𝕩.
+Note: characters are always considered greater than numbers, even ∞.
+"
+                   "Examples:
 ## Monadic form
 < \"singleton\"
    ┌·
@@ -501,22 +422,17 @@ Even ↕10
    1
 
 'a' < ∞
-   0"]
-
-      ;; ================================================
-      ;; greater than
-">"
-
-["Monad: Merge | Dyad: Greater than | Input: >"
-
- "> is a function.
-  It monadic form ensures that any inner arrays, in its argument,
-    can fit together in an array (i.e. flatten ragged inner arrays).
-  Its dyadic form returns the result comparing 𝕨 with 𝕩.
-  Note: characters are always considered greater than numbers, even ∞"
-
- "Examples:
-
+   0
+"])
+                 (">" .
+                  ["Monad: Merge | Dyad: Greater than | Input: >"
+                   "> is a function.
+- It monadic form ensures that any inner arrays, in its argument, can fit
+  together in an array (i.e. flatten ragged inner arrays).
+- Its dyadic form returns the result comparing 𝕨 with 𝕩.
+Note: characters are always considered greater than numbers, even ∞.
+"
+                   "Examples:
 ## Monadic form
 a ← \"AB\"‿\"CD\" ∾⌜ \"rst\"‿\"uvw\"‿\"xyz\"
    ┌─
@@ -550,23 +466,16 @@ a ← \"AB\"‿\"CD\" ∾⌜ \"rst\"‿\"uvw\"‿\"xyz\"
    1
 
 ∞ > 'z'
-   0"]
-
-      ;; ================================================
-      ;; Boolean functions
-      ;; Sort Up
-"∧"
-
-["Monad: Sort Up | Dyad: Logical And | Input: \\t"
-
- "∧ is a function.
-  Its monadic form reorders the major cells of its argument to place them in
-    ascending order.
-  Its dyadic form returns the result of a logical And on the input arguments.
-  "
-
- "Examples:
-
+   0
+"])
+                 ("∧" .
+                  ["Monad: Sort Up | Dyad: Logical And | Input: \\t"
+                   "∧ is a function.
+- Its monadic form reorders the major cells of its argument to place them in
+  ascending order.
+- Its dyadic form returns the result of a logical And on the input arguments.
+"
+                   "Examples:
 ## Monadic form
 ∧ \"delta\"‿\"alpha\"‿\"beta\"‿\"gamma\"
    ⟨ \"alpha\" \"beta\" \"delta\" \"gamma\" ⟩
@@ -597,22 +506,16 @@ a ← \"AB\"‿\"CD\" ∾⌜ \"rst\"‿\"uvw\"‿\"xyz\"
    1
 
 ∧´ 'a'≤ \"purple\"
-   1"]
-
-      ;; ================================================
-      ;; Sort Up
-"∨"
-
-["Monad: Sort Down | Dyad: Logical Or | Input: \\v"
-
- "∨ is a function.
-  Its monadic form reorders the major cells of its argument to place them in
-    descending order.
-  Its dyadic form returns the result of a logical Or on the input arguments.
-  "
-
- "Examples:
-
+   1
+"])
+                 ("∨" .
+                  ["Monad: Sort Down | Dyad: Logical Or | Input: \\v"
+                   "∨ is a function.
+- Its monadic form reorders the major cells of its argument to place them in
+  descending order.
+- Its dyadic form returns the result of a logical Or on the input arguments.
+"
+                   "Examples:
 ## Monadic form
 ∨ \"delta\"‿\"alpha\"‿\"beta\"‿\"gamma\"
    ⟨ \"gamma\" \"delta\" \"beta\" \"alpha\" ⟩
@@ -643,24 +546,19 @@ a ← \"AB\"‿\"CD\" ∾⌜ \"rst\"‿\"uvw\"‿\"xyz\"
    1
 
 ∨´ 'z'≤ \"purple\"
-   0 "]
-
-      ;; ================================================
-      ;; Boolean Not
-"¬"
-
-["Monad: Not | Dyad: Span | Input: \\~"
-
- "¬ is a function.
-  Its monadic form returns the Boolean negation of its input.
-  Its dyadic form returns the number of integers separating 𝕨 from 𝕩, inclusive,
-    only when 𝕩≤𝕨 and both are integers.
-  Note: defined as the fork, 1+-
-        considered an arithmetic function.
-        considered pervasive."
-
- "Examples:
-
+   0
+"])
+                 ("¬" .
+                  ["Monad: Not | Dyad: Span | Input: \\~"
+                   "¬ is a function.
+- Its monadic form returns the Boolean negation of its input.
+- Its dyadic form returns the number of integers separating 𝕨 from 𝕩, inclusive,
+  only when 𝕩≤𝕨 and both are integers.
+Note: defined as the fork, 1+-
+      - considered an arithmetic function.
+      - considered pervasive.
+"
+                   "Examples:
 ## Monadic form
 ¬ 0
    1
@@ -673,7 +571,6 @@ a ← \"AB\"‿\"CD\" ∾⌜ \"rst\"‿\"uvw\"‿\"xyz\"
 
 ¬ ˜1‿0‿1‿2‿3
    ⟨ 1 1 1 1 1 ⟩
-
 
 ## Dyadic form
 ## Notice 0 is counted
@@ -690,25 +587,18 @@ a ← \"AB\"‿\"CD\" ∾⌜ \"rst\"‿\"uvw\"‿\"xyz\"
    ¯1
 
 'a' ¬ @
-   98"]
-
-      ;; ================================================
-      ;; Equality
-"≡"
-
-["Monad: Depth | Dyad: Match | Input: \\m"
-
- "≡ is a function.
-  Its monadic form returns the depth (i.e. the level of nesting) of its input.
-  Its dyadic form tests equivalency between 𝕩 and 𝕨, returns 1 if equivalent
-    and 0 otherwise.
-  Note: see related function ≢ (Not Match)
-        always returns the same result as = (Equals) when 𝕩 and 𝕨 are atoms.
+   98
+"])
+                 ("≡" .
+                  ["Monad: Depth | Dyad: Match | Input: \\m"
+                   "≡ is a function.
+- Its monadic form returns the depth (i.e. the level of nesting) of its input.
+- Its dyadic form tests equivalency between 𝕩 and 𝕨, returns 1 if equivalent
+  and 0 otherwise.
+Note: see related function ≢ (Not Match)
+      always returns the same result as = (Equals) when 𝕩 and 𝕨 are atoms.
 "
-
-
- "Examples:
-
+                   "Examples:
 ## Monadic form
 ≡ 'a'
    0
@@ -736,27 +626,21 @@ a ← \"AB\"‿\"CD\" ∾⌜ \"rst\"‿\"uvw\"‿\"xyz\"
 \"abc\" = \"ab\"
    Error: =: Expected equal shape prefix (⟨3⟩ ≡ ≢𝕨, ⟨2⟩ ≡ ≢𝕩)
 at \"abc\" = \"ab\"
-         ^"]
-
-      ;; ================================================
-      ;; Shape
-"≢"
-
-["Monad: Shape | Dyad: Not Match | Input: \\M"
-
- "≢ is a function.
-  Its monadic form returns the shape of its input. The shape is a list of natural
-    numbers.
-  Its dyadic form tests in-equivalency between 𝕩 and 𝕨, returns 0 if equivalent
-    and 1 otherwise.
-  Note: = (Rank) and ≠ (Length) can be derived from ≢ (Shape).
-        Rank can be defined as =∘≢
-        Length can be defined as a fold: 1⊣´≢
-        See related function ⥊ (Reshape)"
-
-
- "Examples:
-
+         ^
+"])
+                 ("≢" .
+                  ["Monad: Shape | Dyad: Not Match | Input: \\M"
+                   "≢ is a function.
+- Its monadic form returns the shape of its input. The shape is a list of
+  natural numbers.
+- Its dyadic form tests in-equivalency between 𝕩 and 𝕨, returns 0 if equivalent
+  and 1 otherwise.
+Note: = (Rank) and ≠ (Length) can be derived from ≢ (Shape).
+      Rank can be defined as =∘≢
+      Length can be defined as a fold: 1⊣´≢
+      See related function ⥊ (Reshape)
+"
+                   "Examples:
 ## Monadic form
 ## Make a 4-dimensional array of length 1, rank 4
 ## The only element is an array of shape 3‿2‿6, i.e., an array with 3-elements
@@ -782,7 +666,6 @@ at \"abc\" = \"ab\"
 = array # Rank
    4
 
-
 ## Dyadic form
 \"abc\" ≢ 'a'‿'b'‿'c'
    0  ## equivalent
@@ -797,21 +680,15 @@ at \"abc\" = \"ab\"
 \"abc\" = \"ab\"
    Error: =: Expected equal shape prefix (⟨3⟩ ≡ ≢𝕨, ⟨2⟩ ≡ ≢𝕩)
 at \"abc\" = \"ab\"
-         ^"]
-
-      ;; ================================================
-      ;; Left Identity
-"⊣"
-
-["Monad: Identity | Dyad: Left | Input: \\{"
-
- "⊣ is a function.
-  Its monadic form returns its input.
-  Its dyadic form returns 𝕨."
-
-
- "Examples:
-
+         ^
+"])
+                 ("⊣" .
+                  ["Monad: Identity | Dyad: Left | Input: \\{"
+                   "⊣ is a function.
+- Its monadic form returns its input.
+- Its dyadic form returns 𝕨.
+"
+                   "Examples:
 ## Monadic form
 ⊣ 1
    1
@@ -862,21 +739,15 @@ a ← \"hello I'm a\"
    \"hello I'm a\"
 
 a ⌽∘⊣↩ @
-   \"a m'I olleh\""]
-
-      ;; ================================================
-      ;; Right Identity
-"⊢"
-
-["Monad: Identity | Dyad: Right | Input: \\}"
-
- "⊢ is a function.
-  Its monadic form returns its input.
-  Its dyadic form returns 𝕩 (its right argument)."
-
-
- "Examples:
-
+   \"a m'I olleh\"
+"])
+                 ("⊢" .
+                  ["Monad: Identity | Dyad: Right | Input: \\}"
+                   "⊢ is a function.
+- Its monadic form returns its input.
+- Its dyadic form returns 𝕩 (its right argument).
+"
+                   "Examples:
 ## Monadic form
 ⊢ 1
    1
@@ -890,7 +761,6 @@ a ⌽∘⊣↩ @
      · ⟨ 0 1 2 3 4 5 6 7 8 9 ⟩
                                ┘
                                  ┘
-
 
 ## Dyadic form
 \"left\" ⊢ \"right\"
@@ -907,31 +777,25 @@ a ⌽∘⊣↩ @
    3
 
 ÷⟜2⍟3 24
-   3"]
-
-      ;; ================================================
-      ;; Reshape
-"⥊"
-
-["Monad: Deshape | Dyad: Reshape | Input: \\z"
-
- "⥊ is a function.
-  Its monadic form removes all shape information from its input. Returning a
-    list of all elements from the array in reading order.
-  Its dyadic form ignores the shape information of 𝕩 and adds shape information
-    based on 𝕨.
-  Note: in its dyadic form, one entry of 𝕨 may be left for BQN to fill in.
-        when the number of elements implied by 𝕨 is equal to the number of
-          elements in 𝕩, 𝕩 is rearranged to match that shape.
-        when 𝕨 implies less elements than 𝕩 has, then only as many elements
-          as needed from 𝕩 are used, and the rest ignored.
-        when 𝕨 implies more elements than 𝕩 has, then the elements of 𝕩 are
-          reused cyclically.
-        see related function ≍ (Solo)."
-
-
- "Examples:
-
+   3
+"])
+                 ("⥊" .
+                  ["Monad: Deshape | Dyad: Reshape | Input: \\z"
+                   "⥊ is a function.
+- Its monadic form removes all shape information from its input. Returning a
+  list of all elements from the array in reading order.
+- Its dyadic form ignores the shape information of 𝕩 and adds shape information
+  based on 𝕨.
+Note: in its dyadic form, one entry of 𝕨 may be left for BQN to fill in.
+      - when the number of elements implied by 𝕨 is equal to the number of
+        elements in 𝕩, 𝕩 is rearranged to match that shape.
+      - when 𝕨 implies less elements than 𝕩 has, then only as many elements
+        as needed from 𝕩 are used, and the rest ignored.
+      - when 𝕨 implies more elements than 𝕩 has, then the elements of 𝕩 are
+        reused cyclically.
+      see related function ≍ (Solo).
+"
+                   "Examples:
 ## Monadic form
 ## Deshape returns a list in reading order: left to right, top to bottom.
 ⊢ a ← +⌜´ ⟨100‿200, 30‿40, 5‿6‿7⟩
@@ -1036,22 +900,16 @@ at 2‿∘ ⥊ \"abcde\"
    ┌─
    ╵\"abc
      de \"
-         ┘"]
-
-      ;; ================================================
-      ;; Join
-"∾"
-
-["Monad: Join | Dyad: Join to | Input: \,"
-
- "∾ is a function.
-  Its monadic form concatenates the elements of its input.
-  Its dyadic form returns an array whose major cells are the major cells from
-     𝕨 followed by the major cells of 𝕩."
-
-
- "Examples:
-
+         ┘
+"])
+                 ("∾" .
+                  ["Monad: Join | Dyad: Join to | Input: \,"
+                   "∾ is a function.
+- Its monadic form concatenates the elements of its input.
+- Its dyadic form returns an array whose major cells are the major cells from
+  𝕨 followed by the major cells of 𝕩.
+"
+                   "Examples:
 ## Monadic form
 ∾ \"time\"‿\"to\"‿\"join\"‿\"some\"‿\"words\"
    \"timetojoinsomewords\"
@@ -1118,7 +976,6 @@ at ∾ \"abcd\"
      6 30 36 42 48
                    ┘
 
-
 ## Dyadic form
 \"abcd\" ∾ \"EFG\"
    \"abcdEFG\"
@@ -1164,21 +1021,15 @@ at a ∾ 2‿5⥊b  # Shapes don't fit
      0 1 2 3
      1 2 3 4
      2 3 4 5
-             ┘"]
-
-      ;; ================================================
-      ;; 𝕩
-"𝕩"
-
-["Right argument of a block or function | Input: \\x or \\X"
-
- "𝕩 and 𝕏 is a reserved name.
-  It always refers to the right argument of a function.
-  See related form, 𝕨 (left argument)."
-
-
- "Examples:
-
+             ┘
+"])
+                 ("𝕩" .
+                  ["Right argument of a block or function | Input: \\x or \\X"
+                   "𝕩 and 𝕏 are reserved names.
+- It always refers to the right argument of a function.
+- See related form, 𝕨 (left argument).
+"
+                   "Examples:
 ## Use in a block
 {𝕩+1} 2
    3
@@ -1191,21 +1042,15 @@ F ← {𝕩 × 𝕩}
    (function block)
 
 F 2
-   4 "]
-
-      ;; ================================================
-      ;; 𝕏
-"𝕏"
-
-["Right argument of a block or function | Input: \\x or \\X"
-
- "𝕩 and 𝕏 is a reserved name.
-  It always refers to the right argument of a function.
-  See related form, 𝕨 (left argument)."
-
-
- "Examples:
-
+   4
+"])
+                 ("𝕏" .
+                  ["Right argument of a block or function | Input: \\x or \\X"
+                   "𝕩 and 𝕏 are reserved names.
+- It always refers to the right argument of a function.
+- See related form, 𝕨 (left argument).
+"
+                   "Examples:
 ## Use in a block
 {𝕩+1} 2
    3
@@ -1218,28 +1063,28 @@ F ← {𝕩 × 𝕩}
    (function block)
 
 F 2
-   4"]
-
-      ;; ================================================
-      ;; 𝕨
-"𝕨"
-
-["Left argument of a block or function | Input: \\w or \\W"
-
- "𝕨 and 𝕎 is a reserved name.
-  It always refers to the left argument of a function.
-  See related form, 𝕩 (right argument)."
+   4
+"])
 
 
- "Examples:
 
+
+
+                 ("𝕨" .
+                  ["Left argument of a block or function | Input: \\w or \\W"
+                   "𝕨 and 𝕎 are reserved names.
+It always refers to the left argument of a function.
+See related form, 𝕩 (right argument).
+"
+
+
+                   "Examples:
 ## Use in a block
 'c' {𝕨=𝕩} \"abcd\"
    ⟨ 0 0 1 0 ⟩
 
 3 { (2×𝕨)-𝕩 } 1
    5
-
 
 ## When 𝕨 occurs in a function called with one argument, it is filled
 ## with · (Nothing). This use of 𝕨 is discouraged.
@@ -1251,28 +1096,25 @@ F 2
 
 ## Note: this may lead to surprisingly different behavior for ⊸ and ⟜
 { 𝕨 ⋆⊸- 𝕩 } 5
-   143.4131591025766   # · ⋆⊸- 𝕩, expands to, ⋆⊸- 𝕩, which is, (⋆𝕩)-𝕩, not -𝕩"]
+   143.4131591025766   # · ⋆⊸- 𝕩, expands to, ⋆⊸- 𝕩, which is, (⋆𝕩)-𝕩, not -𝕩"])
 
-      ;; ================================================
-      ;; 𝕎
-"𝕎"
 
-["Left argument of a block or function | Input: \\w or \\W"
 
- "𝕨 and 𝕎 is a reserved name.
+                 ("𝕎" .
+                  ["Left argument of a block or function | Input: \\w or \\W"
+
+                   "𝕨 and 𝕎 is a reserved name.
   It always refers to the left argument of a function.
   See related form, 𝕩 (right argument)."
 
 
- "Examples:
-
+                   "Examples:
 ## Use in a block
 'c' {𝕨=𝕩} \"abcd\"
    ⟨ 0 0 1 0 ⟩
 
 3 { (2×𝕨)-𝕩 } 1
    5
-
 
 ## When 𝕨 occurs in a function called with one argument, it is filled
 ## with · (Nothing). This use of 𝕨 is discouraged.
@@ -1284,15 +1126,14 @@ F 2
 
 ## Note: this may lead to surprisingly different behavior for ⊸ and ⟜
 { 𝕨 ⋆⊸- 𝕩 } 5
-   143.4131591025766   # · ⋆⊸- 𝕩, expands to, ⋆⊸- 𝕩, which is (⋆𝕩)-𝕩, not -𝕩"]
+   143.4131591025766   # · ⋆⊸- 𝕩, expands to, ⋆⊸- 𝕩, which is (⋆𝕩)-𝕩, not -𝕩"])
 
-      ;; ================================================
-      ;; Solo
-"≍"
 
-["Monad: Solo | Dyad: Couple | Input: \\."
 
- "≍ is a function.
+                 ("≍" .
+                  ["Monad: Solo | Dyad: Couple | Input: \\."
+
+                   "≍ is a function.
   Its monadic form returns an array with its input as the only major cell.
   Its dyadic form returns an array with elements 𝕩 and 𝕨, and outer axis of
     length-2
@@ -1301,8 +1142,7 @@ F 2
   Note: ≍ ←→ >{⟨𝕩⟩;⟨𝕨,𝕩⟩} or in other words: Solo is {>⟨𝕩⟩}, Couple is {>⟨𝕨,𝕩⟩}"
 
 
- "Examples:
-
+                   "Examples:
 ## Monadic form
 ## Notice that ≍ always adds an axis, thus applied to unit values returns a list
 ≍ 2
@@ -1343,15 +1183,14 @@ p ≍ q   # p coupled to q
 
 ## Notice that the outer axis is length 2 because ≍ had two arguments
 ≢ p ≍ q
-   ⟨ 2 2 3 ⟩"]
+   ⟨ 2 2 3 ⟩"])
 
-      ;; ================================================
-      ;; Pair
-"⋈"
 
-["Monad: Enlist | Dyad: Pair | Input: \\Z"
 
- "⋈ is a function.
+                 ("⋈" .
+                  ["Monad: Enlist | Dyad: Pair | Input: \\Z"
+
+                   "⋈ is a function.
   Its monadic form returns a singleton list containing its input.
   Its dyadic form a list containing both 𝕨 and 𝕩.
   See related form, > (Merge).
@@ -1359,8 +1198,7 @@ p ≍ q   # p coupled to q
   Note: ⋈ ←→ ≍○<, and ≍ ←→ >∘⋈"
 
 
- "Examples:
-
+                   "Examples:
 ## Monadic form
 ⋈ \"enlist\"    # ⟨𝕩⟩
    ⟨ \"enlist\" ⟩
@@ -1393,15 +1231,14 @@ p ≍ q   # p coupled to q
    ┌─
    ╵\"abc
      def\"
-         ┘"]
+         ┘"])
 
-      ;; ================================================
-      ;; Prefixes
-"↑"
 
-["Monad: Prefixes | Dyad: Take | Input: \\r"
 
- "↑ is a function.
+                 ("↑" .
+                  ["Monad: Prefixes | Dyad: Take | Input: \\r"
+
+                   "↑ is a function.
   Its monadic form returns a list of all prefixes of its argument along the
     first axis.
   Its dyadic form returns the first 𝕨 elements of 𝕩.
@@ -1415,8 +1252,7 @@ p ≍ q   # p coupled to q
         See related form, ↓ (Drop)."
 
 
- "Examples:
-
+                   "Examples:
 ## Monadic form
 ↑ \"hello\"              # notice the empty array and input is in the result
    ⟨ ⟨⟩ \"h\" \"he\" \"hel\" \"hell\" \"hello\" ⟩
@@ -1481,15 +1317,14 @@ p ≍ q   # p coupled to q
    ╵ 0 0 0 0 0  0  1  2  3  4  5  6
      0 0 0 0 0 10 11 12 13 14 15 16
      0 0 0 0 0 20 21 22 23 24 25 26
-                                    ┘"]
+                                    ┘"])
 
-      ;; ================================================
-      ;; Suffixes
-"↓"
 
-["Monad: Suffixes | Dyad: Drop | Input: \\c"
 
- "↓ is a function.
+                 ("↓" .
+                  ["Monad: Suffixes | Dyad: Drop | Input: \\c"
+
+                   "↓ is a function.
   Its monadic form returns a list of all suffixes of its argument along the
     first axis.
   Its dyadic form drops the first 𝕨 elements of 𝕩 and returns the rest.
@@ -1502,8 +1337,7 @@ p ≍ q   # p coupled to q
         See related form, ↑ (Take)."
 
 
- "Examples:
-
+                   "Examples:
 ## Monadic form
 ↓ \"hello\"                # notice the empty array and input is in the result
    ⟨ \"hello\" \"ello\" \"llo\" \"lo\" \"o\" ⟨⟩ ⟩
@@ -1518,7 +1352,6 @@ p ≍ q   # p coupled to q
    ┌─
    · ⟨ ⟨⟩ ⟩ ⟨ \"a\" ⟨⟩ ⟩ ⟨ \"ab\" \"b\" ⟨⟩ ⟩ ⟨ \"abc\" \"bc\" \"c\" ⟨⟩ ⟩
                                                              ┘
-
 
 ## Dyadic form
 4 ↓ \"take and drop\"
@@ -1560,15 +1393,14 @@ p ≍ q   # p coupled to q
    ⟨ 1 1 3 ⟩
 
 ≢ (3⥊0) ↓ ↕5‿4‿3‿2
-   ⟨ 5 4 3 2 ⟩"]
+   ⟨ 5 4 3 2 ⟩"])
 
-      ;; ================================================
-      ;; Range
-"↕"
 
-["Monad: Range | Dyad: Windows | Input: \\d"
 
- "↕ is a function.
+                 ("↕" .
+                  ["Monad: Range | Dyad: Windows | Input: \\d"
+
+                   "↕ is a function.
   Its monadic form returns an array where each element's value is its own index.
   Its dyadic form returns ≠𝕩 contiguous slices of 𝕩 that are of length 𝕨.
   Note: (Range) the result always has depth (≡) one more than the argument.
@@ -1576,8 +1408,7 @@ p ≍ q   # p coupled to q
         (Window) slices always have the same rank as the argument array (𝕩)"
 
 
- "Examples:
-
+                   "Examples:
 ## Monadic form, all results are length 6, but elements differ
 ## 𝕩 must be a natural number, notice the result is ≠𝕩, but 𝕩 is not in the result
 ↕6
@@ -1668,7 +1499,6 @@ b × ↕≠b                      # now multiply with b
      ⟨ 1 1 0 ⟩ ⟨ 1 1 1 ⟩
                          ┘
 
-
 ## Dyadic form
 5↕\"abcdefg\"                # get contiguous slices of 𝕩 with length 𝕨
    ┌─
@@ -1697,15 +1527,14 @@ b × ↕≠b                      # now multiply with b
 
 ## Add two zeros to keep the length constant
 (+˝≠↕(2⥊0)⊸∾) ⟨2,6,0,1,4,3⟩
-   ⟨ 2 8 8 7 5 8 ⟩"]
+   ⟨ 2 8 8 7 5 8 ⟩"])
 
-      ;; ================================================
-      ;; Nudge
-"»"
 
-["Monad: Nudge | Dyad: Shift Before | Input: \\L"
 
- "» is a function.
+                 ("»" .
+                  ["Monad: Nudge | Dyad: Shift Before | Input: \\L"
+
+                   "» is a function.
   Its monadic form returns its input where each element has shifted one major
     cell to the right, and the new cell is filled with 0s or \" \".
   Its dyadic form adds 𝕨 to the beginning of 𝕩, while maintiaing the length of 𝕩.
@@ -1717,8 +1546,7 @@ b × ↕≠b                      # now multiply with b
         Shift Before is defined as {(≠𝕩)↑𝕨∾𝕩}
         See related form, « (Nudge Back/Shift After)"
 
- "Examples:
-
+                   "Examples:
 ## Monadic form
 » \"abc\"
    \" ab\"    # notice that the length of the result equals the length of 𝕩
@@ -1745,7 +1573,6 @@ b × ↕≠b                      # now multiply with b
      3 4 5
      6 7 8
            ┘
-
 
 ## Dyadic form, » and « are useful for sequence processing
 s ← 1‿2‿2‿4‿3‿5‿6
@@ -1811,15 +1638,14 @@ s ≍ »s
      'c' 'e' 'l'
      0   1   2
      3   4   5
-                 ┘"]
+                 ┘"])
 
-      ;; ================================================
-      ;; Nudge Back
-"«"
 
-["Monad: Nudge Back | Dyad: Shift After | Input: \\H"
 
- "« is a function.
+                 ("«" .
+                  ["Monad: Nudge Back | Dyad: Shift After | Input: \\H"
+
+                   "« is a function.
   Its monadic form returns its input where each element has shifted one major
     cell to the left, and the new cell is filled with 0s or \" \".
   Its dyadic form adds 𝕨 to the end of 𝕩, while maintaining the length of 𝕩.
@@ -1831,8 +1657,7 @@ s ≍ »s
         Shift After is defined as {(-≠𝕩)↑𝕩∾𝕨}
         See related form, » (Nudge/Shift Before)"
 
- "Examples:
-
+                   "Examples:
 ## Monadic form
 « \"abc\"
    \"bc \"    # notice that the length of the result equals the length of 𝕩
@@ -1859,7 +1684,6 @@ s ≍ »s
      9 10 11
      0  0  0    # new major cell of fills
              ┘
-
 
 ## Dyadic form, » and « are useful for sequence processing
 ## in this example we get a difference between pairs of elements
@@ -1930,15 +1754,14 @@ s ≍ «s
      9   10  11
      't' 'w' 'o'
      'c' 'e' 'l'
-                 ┘"]
+                 ┘"])
 
-      ;; ================================================
-      ;; Reverse
-"⌽"
 
-["Monad: Reverse | Dyad: Rotate | Input: \\q"
 
- "⌽ is a function.
+                 ("⌽" .
+                  ["Monad: Reverse | Dyad: Rotate | Input: \\q"
+
+                   "⌽ is a function.
   Its monadic form returns an array whose major cells are reverse from the input.
   Its dyadic form cycles or rotates the major cells in 𝕩, according to 𝕨.
   Note: Both Reverse and Rotate return an array with the same shape and elements
@@ -1946,8 +1769,7 @@ s ≍ «s
         Avoid Rotate if there is no reason to treat data in 𝕩 as cyclic or
           periodic."
 
- "Examples:
-
+                   "Examples:
 ## Monadic form
 ⌽ \"abcdefg\"
    \"gfedcba\"
@@ -1996,7 +1818,6 @@ at ⌽ 'c'
 
 ∨`⌾⌽ 0‿0‿1‿0‿0‿1‿0
    ⟨ 1 1 1 1 1 1 0 ⟩    # change all bits before the last 1 in the bitstring to 1s
-
 
 ## Dyadic form, for single axis 𝕨 must be an number, 𝕩 must be an array with
 ## at least one axis.
@@ -2067,15 +1888,14 @@ at 3‿4‿2 ⌽ \"just a list\"
    ╵\"CDAB
      2301
      cdab\"
-          ┘"]
+          ┘"])
 
-      ;; ================================================
-      ;; Transpose
-"⍉"
 
-["Monad: Transpose | Dyad: Reorder axes | Input: \\a"
 
- "⍉ is a function.
+                 ("⍉" .
+                  ["Monad: Transpose | Dyad: Reorder axes | Input: \\a"
+
+                   "⍉ is a function.
   Its monadic form returns an array whose first axis has been moved to the end.
   Its dyadic form generalizes the monadic form for arbritrary arrangement of 𝕩,
     according to 𝕨.
@@ -2086,8 +1906,7 @@ at 3‿4‿2 ⌽ \"just a list\"
                        Invariant: ∧´𝕨<r
         see related function, ⌽ (Rotate)"
 
- "Examples:
-
+                   "Examples:
 ## Monadic form
 ## mat is a 2‿3 matrix
 ⊢ mat ← 2‿3 ⥊ ↕6
@@ -2181,15 +2000,14 @@ a322 ← 3‿2‿2⥊↕12
    ⟨ 2 5 3 6 4 ⟩
 
 ≢ 2 ⍉ a23456  # Restrict Transpose to the first three axes
-   ⟨ 3 4 2 5 6 ⟩"]
+   ⟨ 3 4 2 5 6 ⟩"])
 
-      ;; ================================================
-      ;; Indices
-"/"
 
-["Monad: Indices | Dyad: Replicate | Input: \/"
 
- "/ is a function.
+                 ("/" .
+                  ["Monad: Indices | Dyad: Replicate | Input: \/"
+
+                   "/ is a function.
   Its monadic form returns a list of natural numbers that are the indices of 𝕩.
   Its dyadic form repeats each major cell of 𝕩, the corresponding 𝕨 times.
   Note: (Replicate) Invariant: (𝕨≠) ≡ (𝕩≠)
@@ -2199,8 +2017,7 @@ a322 ← 3‿2‿2⥊↕12
 
         (Indices) 𝕩 must be a list of natural numbers, then /𝕩 is 𝕩/↕≠𝕩"
 
- "Examples:
-
+                   "Examples:
 ## Monadic form
 / 3‿0‿1‿2
    ⟨ 0 0 0 2 3 3 ⟩
@@ -2266,7 +2083,6 @@ a322 ← 3‿2‿2⥊↕12
 
 /⁼∧ 2‿2‿4‿1‿2‿0          # note that for /⁼ to work 𝕩 must be sorted, hence ∧
    ⟨ 1 1 3 0 1 ⟩          # this is also typically faster than ≠¨⊔
-
 
 ## Dyadic form
 2‿1‿0‿2 / \"abcd\"
@@ -2346,15 +2162,14 @@ a322 ← 3‿2‿2⥊↕12
 
 ## when 𝕨 is ⟨⟩ we have the base case b ≡ ⟨⟩ / b
 b ≡ ⟨⟩ / b
-   1"]
+   1"])
 
-      ;; ================================================
-      ;; Grade Up
-"⍋"
 
-["Monad: Grade Up | Dyad: Bins Up | Input: \\T"
 
- "⍋ is a function.
+                 ("⍋" .
+                  ["Monad: Grade Up | Dyad: Bins Up | Input: \\T"
+
+                   "⍋ is a function.
   Its monadic form returns a list of natural numbers that are an ascending ording
     of the input.
   Its dyadic form returns a list of natural numbers, where each number indicates
@@ -2363,8 +2178,7 @@ b ≡ ⟨⟩ / b
                   Result is always in ascending sorted order.
         see related function, ⍒ (Grade Down/Bins Down)"
 
- "Examples:
-
+                   "Examples:
 ## Monadic form
 ⊢ l ← \"planet\"‿\"moon\"‿\"star\"‿\"asteroid\"
    ⟨ \"planet\" \"moon\" \"star\" \"asteroid\" ⟩
@@ -2382,7 +2196,6 @@ b ≡ ⟨⟩ / b
 ## and
 ((⍋l) ⊏l) ≡ ∧l
    1
-
 
 ## Dyadic form
 5‿6‿2‿4‿1 ⍋ 3                  # notice 𝕨 is not strictly sorted due to 6‿2‿4
@@ -2403,15 +2216,14 @@ other_scores ← 5‿6‿23          # notice this is sorted due to 𝕨 sorted 
 # rank > 1 is ≥ 5 and if we were to insert 5 and preserve ordering we would do
 # so at index 1
 other_scores ⍋ scores
-   ⟨ 0 1 2 2 3 ⟩"]
+   ⟨ 0 1 2 2 3 ⟩"])
 
-      ;; ================================================
-      ;; Grade Down
-"⍒"
 
-["Monad: Grade Down | Dyad: Bins Down | Input: \\V"
 
- "⍒ is a function.
+                 ("⍒" .
+                  ["Monad: Grade Down | Dyad: Bins Down | Input: \\V"
+
+                   "⍒ is a function.
   Its monadic form returns a list of natural numbers that are a descending ording
     of the input.
   Its dyadic form returns a list of natural numbers, where each number indicates
@@ -2420,8 +2232,7 @@ other_scores ⍋ scores
                   Result is always in descending sorted order.
         see related function, ⍒ (Grade Down/Bins Down)"
 
- "Examples:
-
+                   "Examples:
 ## Monadic form
 ⊢ l ← \"planet\"‿\"moon\"‿\"star\"‿\"asteroid\"
    ⟨ \"planet\" \"moon\" \"star\" \"asteroid\" ⟩
@@ -2439,7 +2250,6 @@ other_scores ⍋ scores
 ## and
 ((⍒l) ⊏l) ≡ ∨l
    1
-
 
 ## Dyadic form
 5‿6‿2‿4‿1 ⍒ 3                  # notice 𝕨 is not strictly sorted due to 6‿2‿4
@@ -2460,15 +2270,14 @@ other_scores ← 23‿6‿5          # notice this is sorted due to 𝕨 sorted 
 # rank < 3 is ≥ 5 and if we were to insert 5 and preserve ordering we would do
 # so at index 3
 other_scores ⍒ scores
-   ⟨ 3 3 1 1 1 ⟩"]
+   ⟨ 3 3 1 1 1 ⟩"])
 
-      ;; ================================================
-      ;; First Cell
-"⊏"
 
-["Monad: First Cell | Dyad: Select | Input: \\i"
 
- "⊏ is a function.
+                 ("⊏" .
+                  ["Monad: First Cell | Dyad: Select | Input: \\i"
+
+                   "⊏ is a function.
   Its monadic form returns the major cell of 𝕩 at index 0.
   Its dyadic form reorganizes 𝕩 along one or more axes according to the indices
     given by 𝕨.
@@ -2483,8 +2292,7 @@ other_scores ⍒ scores
         see related function, ⊑ (Pick)"
 
 
- "Examples:
-
+                   "Examples:
 ## Monadic form
 ⊏ \"abc\"
    ┌·
@@ -2593,28 +2401,28 @@ at ⊏ 'a'
    ┌─
    ╵ ⟨ 2 3 ⟩ ⟨ 2 0 ⟩ ⟨ 2 0 ⟩
      ⟨ 1 3 ⟩ ⟨ 1 0 ⟩ ⟨ 1 0 ⟩
-                             ┘"]
+                             ┘
+"])
 
-      ;; ================================================
-      ;; Pick
-"⊑"
 
-["Monad: First | Dyad: Pick | Input: \\I"
 
- "⊑ is a function.
-  Its monadic form returns the first element of 𝕩 in index order.
-  Its dyadic form returns elements from 𝕩 based on index lists from 𝕨.
-  Note: (First) is Pick where 𝕨 is 0¨≢𝕩
-        (Pick) 𝕨 can be a plain list, a single number, array of index lists,
-                 or have deeper structure.
-               a number in 𝕨 must be an integer, i, where -≠𝕩 < i < ≠𝕩
-               using Pick to repeatedly select multiple elements from 𝕩 is likely
-                 slower than using ⊏. Prefer ⊏ in this case or rearrange your data.
-        see related function, ⊏ (Select)
-        see related function, ⊐ (Classify)"
 
- "Examples:
+                 ("⊑" .
+                  ["Monad: First | Dyad: Pick | Input: \\I"
+                   "⊑ is a function.
+- Its monadic form returns the first element of 𝕩 in index order.
+- Its dyadic form returns elements from 𝕩 based on index lists from 𝕨.
+Note: (First) is Pick where 𝕨 is 0¨≢𝕩
+      (Pick) 𝕨 can be a plain list, a single number, array of index lists, or
+             have deeper structure.
+             a number in 𝕨 must be an integer, i, where -≠𝕩 < i < ≠𝕩
+             using Pick to repeatedly select multiple elements from 𝕩 is likely
+             slower than using ⊏. Prefer ⊏ in this case or rearrange your data.
+      see related function, ⊏ (Select)
+      see related function, ⊐ (Classify)
+"
 
+                   "Examples:
 ## Monadic form
 ⊑ 'a'
    'a'
@@ -2723,26 +2531,20 @@ at ⟨⟨2,3⟩,1⟩ ⊑ a
      ┌·    't'
      ·'q'
          ┘
-                 ┘"]
-
-      ;; ================================================
-      ;; Classify
-"⊐"
-
-["Monad: Classify | Dyad: Index of | Input: \\o"
-
- "⊐ is a function.
-  Its monadic form returns a list of natural numbers, where each number
-    corresponds to the index of first appearance of the corresponding value in 𝕩.
-  Its dyadic form returns a list of indices, where each index is the first
-    occurrence of each entry in 𝕨, in 𝕩.
-  Note: (Classify) is idempotent.
+                 ┘
+"])
+                 ("⊐" .
+                  ["Monad: Classify | Dyad: Index of | Input: \\o"
+                   "⊐ is a function.
+- Its monadic form returns a list of natural numbers, where each number
+  corresponds to the index of first appearance of the corresponding value in 𝕩.
+- Its dyadic form returns a list of indices, where each index is the first
+  occurrence of each entry in 𝕨, in 𝕩.
+Note: (Classify) is idempotent.
         see related function, ⍷ (Deduplicate)
-        see related function, ⊒ (Occurence Count)"
-
-
- "Examples:
-
+        see related function, ⊒ (Occurence Count)
+"
+                   "Examples:
 ## Monadic form
 # notice that 5 is at index 0, and so 0's are in 5's position in the result
 ⊐ 5‿6‿2‿2‿5‿1
@@ -2788,30 +2590,24 @@ at ⟨⟨2,3⟩,1⟩ ⊑ a
 ⊐ ⊐ ⊐ c
    ⟨ 0 1 0 2 1 0 ⟩
 
-
 ## Dyadic form
 \"zero\"‿\"one\"‿\"two\"‿\"three\" ⊐ \"one\"‿\"eight\"‿\"two\"
-   ⟨ 1 4 2 ⟩"]
-
-      ;; ================================================
-      ;; Occurrence Count
-"⊒"
-
-["Monad: Occurrence Count | Dyad: Progressive Index of | Input: \\O"
-
- "⊒ is a function.
-  Its monadic form returns a list of natural numbers, where each number
-    is the number of previous cells that match the current cell.
-  Its dyadic form returns a list of indices, where each index is either the first
-    occurrence of each entry in 𝕨, in 𝕩, or the first unused match if there is one.
-  Note: (Progressive Index of) no index except ≠𝕨 can be repeated.
-                               use ⊒˜<≠∘⊢ for Progressive Membership of
-                               ⊒˜ is the same as ↕∘≠
-        see related function, ⊐ (Classify)"
-
-
- "Examples:
-
+   ⟨ 1 4 2 ⟩
+"])
+                 ("⊒" .
+                  ["Monad: Occurrence Count | Dyad: Progressive Index of | Input: \\O"
+                   "⊒ is a function.
+- Its monadic form returns a list of natural numbers, where each number is the
+  number of previous cells that match the current cell.
+- Its dyadic form returns a list of indices, where each index is either the
+  first occurrence of each entry in 𝕨, in 𝕩, or the first unused match if there
+  is one.
+Note: (Progressive Index of)
+         no index except ≠𝕨 can be repeated.
+         use ⊒˜<≠∘⊢ for Progressive Membership of
+         ⊒˜ is the same as ↕∘≠
+      see related function, ⊐ (Classify)"
+                   "Examples:
 ## Monadic form
 ⊒   2‿7‿1‿8‿1‿7‿1‿8‿2‿8‿4
    ⟨ 0 0 0 0 1 1 2 1 1 2 0 ⟩    # notice a 1 at the next occurrence of 1 in 𝕩
@@ -2839,7 +2635,6 @@ at ⟨⟨2,3⟩,1⟩ ⊑ a
 (/(¯1⊸⊑↕⊸-⊏⟜»)+`) 2‿3‿4
    ⟨ 0 1 0 1 2 0 1 2 3 ⟩
 
-
 ## Dyadic form
 \"aaa\" ⊒ \"aaaaa\"      # the first 3 'a's match, but the last two are unused
    ⟨ 0 1 2 3 3 ⟩
@@ -2848,24 +2643,18 @@ at ⟨⟨2,3⟩,1⟩ ⊑ a
 ## and the first two 'b's to indices 3 and 4 of 𝕨, then we only have unused
 ## matches so ≠𝕨 is used.
 \"aaabb\" ⊒ \"ababababab\"
-   ⟨ 0 3 1 4 2 5 5 5 5 5 ⟩"]
-
-      ;; ================================================
-      ;; Mark Firsts
-"∊"
-
-["Monad: Mark Firsts | Dyad: Member of | Input: \\e"
-
- "∊ is a function.
-  Its monadic form returns a list of booleans, where each number is either a 0,
-    if the major cell of 𝕩 is a duplicate of a previous cell, or 1 otherwise.
-  Its dyadic form returns a list of numbers of length ≠𝕨, each number is either
-    a 0 or 1. A 1 indicates an entry of 𝕨 matches some entry in 𝕩, a 0 otherwise.
-  Note: see related function, ⍷ (Deduplicate)"
-
-
- "Examples:
-
+   ⟨ 0 3 1 4 2 5 5 5 5 5 ⟩
+"])
+                 ("∊" .
+                  ["Monad: Mark Firsts | Dyad: Member of | Input: \\e"
+                   "∊ is a function.
+- Its monadic form returns a list of booleans, where each number is either a 0,
+  if the major cell of 𝕩 is a duplicate of a previous cell, or 1 otherwise.
+- Its dyadic form returns a list of numbers of length ≠𝕨, each number is either
+  a 0 or 1. A 1 indicates an entry of 𝕨 matches some entry in 𝕩, a 0 otherwise.
+Note: see related function, ⍷ (Deduplicate)
+"
+                   "Examples:
 ## Monadic form
 ∊   3‿1‿4‿1‿5‿9‿2‿6‿5
    ⟨ 1 1 1 0 1 1 1 1 0 ⟩     # notice the first duplicate 1, corresponds to a 0
@@ -2896,7 +2685,6 @@ at ⟨⟨2,3⟩,1⟩ ⊑ a
 (∊∧∊⌾⌽) \"duck\"‿\"duck\"‿\"teal\"‿\"duck\"‿\"goose\"
    ⟨ 0 0 1 0 1 ⟩
 
-
 ## Dyadic form
 ## results are independent of the ordering of 𝕩
 \"green\"‿\"bricks\"‿\"cow\"‿\"blue\" ∊ \"red\"‿\"green\"‿\"blue\"
@@ -2907,27 +2695,23 @@ at ⟨⟨2,3⟩,1⟩ ⊑ a
    \"initiset\"
 
 \"initial set\" (¬∘∊/⊣) \"difference\"  # Remove 𝕩
-   \"tal st\""]
-
-      ;; ================================================
-      ;; Deduplicate
-"⍷"
-
-["Monad: Deduplicate | Dyad: Find | Input: \\E"
-
- "⍷ is a function.
-  Its monadic form removes every major cell that matches an earlier cell.
-  Its dyadic form searches for occurrences of an array 𝕨, in 𝕩. The result is a
-    list of booleans for each possible location.
-  Note: (Deduplicate) can be implemented as ∊⊸/
-                      see related function, ⊐ (Classify)
-        (Find)        𝕨 needs to match a contiguous section of 𝕩
-                      there is no guarantee the result maintains the shape of 𝕩
-                      if ≠𝕨 > ≠𝕩 then the result is empty"
-
-
- "Examples:
-
+   \"tal st\"
+"])
+                 ("⍷" .
+                  ["Monad: Deduplicate | Dyad: Find | Input: \\E"
+                   "⍷ is a function.
+- Its monadic form removes every major cell that matches an earlier cell.
+- Its dyadic form searches for occurrences of an array 𝕨, in 𝕩. The result is a
+  list of booleans for each possible location.
+Note: (Deduplicate)
+         can be implemented as ∊⊸/
+         see related function, ⊐ (Classify)
+      (Find)
+         𝕨 needs to match a contiguous section of 𝕩
+         there is no guarantee the result maintains the shape of 𝕩
+         if ≠𝕨 > ≠𝕩 then the result is empty
+"
+                   "Examples:
 ## Monadic form
 ⍷ >\"take\"‿\"drop\"‿\"drop\"‿\"pick\"‿\"take\"‿\"take\"
    ┌─
@@ -2943,7 +2727,6 @@ at ⟨⟨2,3⟩,1⟩ ⊑ a
      pick
      take\"
           ┘
-
 
 ## Dyadic form
 \"xx\" ⍷ \"xxbdxxxcx\"        # a contiguous match for strings is a substring
@@ -3024,24 +2807,17 @@ at 9 ↕ \"short\"
      1 0 1 0 1 0
      0 0 0 0 0 0
      1 0 1 0 1 0
-                 ┘"]
-
-      ;; ================================================
-      ;; Group
-"⊔"
-
-["Monad: Group Indices | Dyad: Group | Input: \\u"
-
- "⊔ is a function.
-  Its monadic form returns a list of lists of indices, where each sublist
-    contains indices of equal elements of 𝕩.
-  Its dyadic form returns a list of groups, each containing cells from 𝕩,
-    according to a list of atomic indices in 𝕨.
-  Note: (Group) 𝕨 and 𝕩 must have the same length"
-
-
- "Examples:
-
+                 ┘
+"])
+                 ("⊔" .
+                  ["Monad: Group Indices | Dyad: Group | Input: \\u"
+                   "⊔ is a function.
+- Its monadic form returns a list of lists of indices, where each sublist
+  contains indices of equal elements of 𝕩.
+- Its dyadic form returns a list of groups, each containing cells from 𝕩,
+  according to a list of atomic indices in 𝕨.
+Note: (Group) 𝕨 and 𝕩 must have the same length"
+                   "Examples:
 ## Monadic form
 ⊔ 0‿2‿5‿3‿2
    ⟨ ⟨ 0 ⟩ ⟨⟩ ⟨ 1 4 ⟩ ⟨ 3 ⟩ ⟨⟩ ⟨ 2 ⟩ ⟩     # 2 is at index 1 and 4, 3 is unique hence ⟨⟩
@@ -3050,7 +2826,6 @@ at 9 ↕ \"short\"
    Error: ⊔: Grouping argument must consist of integers
 at ⊔ \"abcdab\"
    ^
-
 
 ## Dyadic form
 0‿1‿2‿0‿1 ≍ \"abcde\"  # Corresponding indices and values
@@ -3142,23 +2917,18 @@ countries ≍˘ co countries⊸(⊐∾≠∘⊣)⊸⊔ ln
      \"NO\" ⟨ \"Bjørgen\" \"Bjørndalen\" ⟩
      \"SU\" ⟨ \"Latynina\" \"Andrianov\" ⟩
      \"US\" ⟨ \"Phelps\" ⟩
-                                     ┘"]
-
-      ;; ================================================
-      ;; Assert
-"!"
-
-["Monad: Assert | Dyad: Assert with message | Input: !"
-
- "! is a function.
-  Its monadic form tests that 𝕩 is 1, if it is then it returns 𝕩, otherwise it
-    throws an Error.
-  Its dyadic form returns a message with the error thrown.
-  Note: (Assert) the right argument must be exactly 1, or 0."
-
-
- "Examples:
-
+                                     ┘
+"])
+                 ("!" .
+                  ["Monad: Assert | Dyad: Assert with message | Input: !"
+                   "! is a function.
+- Its monadic form tests that 𝕩 is 1,
+  - if it is then it returns 𝕩
+  - otherwise it throws an Error.
+- Its dyadic form returns a message with the error thrown.
+- Note: (Assert) the right argument must be exactly 1, or 0.
+"
+                   "Examples:
 ## Monadic form
 ! 2=2  # Passed
    1
@@ -3192,9 +2962,12 @@ MyError ← {𝕨 \"My custom error\"⊸!⍟(1⊸≢) 𝕩}
 at MyError ← {𝕨 \"My custom error\"⊸!⍟(1⊸≢) 𝕩}
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 at \"hello\" MyError 0
-           ^^^^^^^"]))
-
-
+           ^^^^^^^
+"])))
+        (ht (make-hash-table :test 'equal)))
+    (dolist (entry table)
+      (puthash (car entry) (cdr entry) ht))
+    ht)
   "This table associates BQN symbols as hash-keys to a 3-vector of docstrings.
 Position 0 is short description for eldoc, position 1 is a long description,
 and position 2 is any extra description.")


### PR DESCRIPTION
Instead of hardcoding the low-level structure of hash table, uses a more typical
list of cons cells as intermediary and convert it afterwards.

Extracted from #22