### PR TITLE
consolidate inferior-process send commands, prefix arg to follow

### DIFF
--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -519,11 +519,10 @@ If it doesn't exist, create and return it; else, return the existing one."
       (bqn-comint-mode)
       (set-input-method "BQN-Z"))))
 
-(defun bqn-comint-process-execute-region (start end &optional dont-follow)
+(defun bqn-comint-process-execute-region (start end &optional follow)
   "Send the region bounded by START and END to the bqn-comint-process-session.
 
-When DONT-FOLLOW is non-nil, maintain focus on the buffer where
-the function was called from."
+When FOLLOW is non-nil, switch to the inferior process buffer."
   (interactive "r")
   (when (= start end)
     (error
@@ -541,25 +540,19 @@ the function was called from."
     (when (or dont-follow nil)
       (pop-to-buffer buffer))))
 
-(defun bqn-comint-process-execute-line-and-follow ()
-  "Send the current line to BQN process and focus BQN process buffer."
-  (interactive)
-  (bqn-comint-process-execute-region (line-beginning-position) (line-end-position)))
+(defun bqn-comint-process-execute-line (&optional arg)
+  "Send the active region, else the current line to the BQN process."
+  (interactive "P")
+  (cond
+   ((use-region-p)
+    (bqn-comint-process-execute-region (region-beginning) (region-end) arg))
+   (t
+    (bqn-comint-process-execute-region (line-beginning-position) (line-end-position) arg))))
 
-(defun bqn-comint-process-execute-buffer-and-follow ()
-  "Send the current buffer to BQN process and focus BQN process buffer."
-  (interactive)
-  (bqn-comint-process-execute-region (point-min) (point-max)))
-
-(defun bqn-comint-process-execute-line ()
-  "Send the line containing the point to the BQN process."
-  (interactive)
-  (bqn-comint-process-execute-region (line-beginning-position) (line-end-position) t))
-
-(defun bqn-comint-process-execute-buffer ()
+(defun bqn-comint-process-execute-buffer (&optional arg)
   "Send the current buffer to BQN process."
-  (interactive)
-  (bqn-comint-process-execute-region (point-min) (point-max) t))
+  (interactive "P")
+  (bqn-comint-process-execute-region (point-min) (point-max) arg))
 
 (define-derived-mode bqn-comint-mode comint-mode "BQN interactive"
   "Major mode for inferior BQN processes."


### PR DESCRIPTION
This removes the `-and-follow' command variants.  When working in a
source buffer, it is common to send many parts to the inferior process,
staying in the source buffer.  Switching to the inferior process is the
exception from that, and a wonderful use of the optional prefix arg.

Also for a more DWIM behavior, when a region is active, send that
instead of the current line.