### PR TITLE
derive both bqn-{keymap,glyph}-mode from special-mode, rm keymaps etc

### DIFF
--- a/bqn-glyph-mode.el
+++ b/bqn-glyph-mode.el
@@ -45,20 +45,6 @@
 
 (defvar bqn-glyph-mode-*buffer-name* "*BQN Glyphs*")
 
-(defvar bqn-glyph-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "q") 'bqn-glyph-mode-kill-buffer)
-    map)
-  "Keymap for keymap mode buffers.")
-
-(defun bqn-glyph-mode-kill-buffer ()
-  "Close the buffer displaying the keymap."
-  (interactive)
-  (let ((buffer (get-buffer bqn-glyph-mode-*buffer-name*)))
-    (when buffer
-      (delete-windows-on buffer)
-      (kill-buffer buffer))))
-
 (defun bqn-glyph-mode-show-glyphs ()
   "Display a table of BQN glyphs."
   (interactive)
@@ -74,9 +60,8 @@
         (set-window-buffer window buffer)
         (fit-window-to-buffer window)))))
 
-(define-derived-mode bqn-glyph-mode fundamental-mode "BQN-Glyphs"
+(define-derived-mode bqn-glyph-mode special-mode "BQN-Glyphs"
   "Major mode for displaying the BQN Glyph help."
-  (use-local-map bqn-glyph-mode-map)
   (buffer-face-set 'bqn-default)
   (read-only-mode 1)
   (setq truncate-lines t))

--- a/bqn-keymap-mode.el
+++ b/bqn-keymap-mode.el
@@ -34,20 +34,6 @@
 (defvar bqn-keymap-mode-*buffer-name* "*BQN keymap*"
   "Name of the BQN keymap buffer.")
 
-(defvar bqn-keymap-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "q") 'bqn-keymap-mode-kill-buffer)
-    map)
-  "Keymap for keymap mode buffers.")
-
-(defun bqn-keymap-mode-kill-buffer ()
-  "Close the buffer displaying the keymap."
-  (interactive)
-  (let ((buffer (get-buffer bqn-keymap-mode-*buffer-name*)))
-    (when buffer
-      (delete-windows-on buffer)
-      (kill-buffer buffer))))
-
 (defun bqn-keymap-mode-show-keyboard ()
   "Display the keyboard help."
   (interactive)
@@ -63,9 +49,8 @@
         (set-window-buffer window buffer)
         (fit-window-to-buffer window)))))
 
-(define-derived-mode bqn-keymap-mode fundamental-mode "BQN-Keymap"
+(define-derived-mode bqn-keymap-mode special-mode "BQN-Keymap"
   "Major mode for displaying the keymap help."
-  (use-local-map bqn-keymap-mode-map)
   (buffer-face-set 'bqn-default)
   (read-only-mode 1)
   (setq truncate-lines t))


### PR DESCRIPTION
This change is analogous to the earlier code cleanup for
`bqn-help-documentation-mode`.