### PR TITLE
Help cleanup

### DIFF
--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -341,20 +341,6 @@
 ;; General interactive help
 (defvar bqn-help-*documentation-buffer-name* "*bqn-help*")
 
-(defun bqn-help--bqn-symbols-info (test)
-  "Find entry in `bqn-symbols--list' using the filter functionp TEST."
-  (seq-filter test bqn-symbols--list))
-
-(defun bqn-help-symbol-at-point-is-called ()
-  "Show the canonical name of the symbol at point in the minibuffer."
-  (interactive)
-  (when (looking-at bqn-help--function-regexp)
-    (if-let* ((symbol (match-string 0))
-              (result (bqn-help--bqn-symbols-info
-                       (lambda (v) (equal (cadr v) symbol)))))
-        (message "We call symbol %s %s" symbol (caar result))
-      (message "No name for %s found" symbol))))
-
 (defun bqn-help-symbol-info-at-point ()
   "Get multi-line documentation for the thing at point, or nil."
   (interactive)

--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -328,7 +328,7 @@
   (when (looking-at bqn-help--function-regexp)
     (bqn-symbols-doc-get-short-doc (match-string 0))))
 
-(define-derived-mode bqn-help-documentation-mode special-mode
+(define-derived-mode bqn-help--mode special-mode
   "BQN Documentation"
   "Major mode for displaying BQN documentation."
   (setq-local font-lock-defaults bqn--font-lock-defaults)
@@ -349,7 +349,7 @@
             (erase-buffer)
             (insert long sep extra))
           (goto-char (point-min))
-          (bqn-help-documentation-mode)
+          (bqn-help--mode)
           (display-buffer doc-buffer))
       (message "No help for %s found!" symbol))))
 

--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -319,13 +319,13 @@
     table)
   "Syntax table for `bqn-mode'.")
 
-(defvar bqn-help--function-regexp
+(defvar bqn-help--regexp
   (regexp-opt (append (mapcar #'cadr bqn-symbols--list)
                       (bqn-symbols-doc--symbols)))
   "Regex to match BQN functions.")
 
 (defun bqn-help--eldoc ()
-  (when (looking-at bqn-help--function-regexp)
+  (when (looking-at bqn-help--regexp)
     (bqn-symbols-doc-get-short-doc (match-string 0))))
 
 (define-derived-mode bqn-help--mode special-mode
@@ -338,7 +338,7 @@
 (defun bqn-help-symbol-info-at-point ()
   "Show full documentation for the primitve at point in a separate buffer."
   (interactive)
-  (unless (looking-at bqn-help--function-regexp)
+  (unless (looking-at bqn-help--regexp)
     (user-error "No BQN primitive at point"))
   (if-let* ((symbol (match-string 0))
             (long   (bqn-symbols-doc-get-long-doc symbol))

--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -338,20 +338,21 @@
 (defun bqn-help-symbol-info-at-point ()
   "Show full documentation for the primitve at point in a separate buffer."
   (interactive)
-  (when (looking-at bqn-help--function-regexp)
-    (if-let* ((symbol (match-string 0))
-              (long   (bqn-symbols-doc-get-long-doc symbol))
-              (extra  (bqn-symbols-doc-get-extra-doc symbol))
-              (sep    "\n\n========================================\n\n")
-              (doc-buffer (get-buffer-create "*bqn-help*")))
-        (with-current-buffer doc-buffer
-          (let ((inhibit-read-only t))
-            (erase-buffer)
-            (insert long sep extra))
-          (goto-char (point-min))
-          (bqn-help--mode)
-          (display-buffer doc-buffer))
-      (message "No help for %s found!" symbol))))
+  (unless (looking-at bqn-help--function-regexp)
+    (user-error "No BQN primitive at point"))
+  (if-let* ((symbol (match-string 0))
+            (long   (bqn-symbols-doc-get-long-doc symbol))
+            (extra  (bqn-symbols-doc-get-extra-doc symbol))
+            (sep    "\n\n========================================\n\n")
+            (doc-buffer (get-buffer-create "*bqn-help*")))
+      (with-current-buffer doc-buffer
+        (let ((inhibit-read-only t))
+          (erase-buffer)
+          (insert long sep extra))
+        (goto-char (point-min))
+        (bqn-help--mode)
+        (display-buffer doc-buffer))
+    (message "No help for %s found!" symbol))) ;should never happen
 
 (defun bqn--make-glyph-map (modifier)
   "Create a new keymap using the string prefix MODIFIER."

--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -319,7 +319,6 @@
     table)
   "Syntax table for `bqn-mode'.")
 
-;; Eldoc functions
 (defvar bqn-help--function-regexp
   (regexp-opt (append (mapcar #'cadr bqn-symbols--list)
                       (bqn-symbols-doc--symbols)))
@@ -329,7 +328,6 @@
   (when (looking-at bqn-help--function-regexp)
     (bqn-symbols-doc-get-short-doc (match-string 0))))
 
-;; Help functions
 (define-derived-mode bqn-help-documentation-mode special-mode
   "BQN Documentation"
   "Major mode for displaying BQN documentation."
@@ -337,7 +335,6 @@
   (setq-local eldoc-documentation-function #'bqn-help--eldoc)
   (buffer-face-set 'bqn-default))
 
-;; General interactive help
 (defun bqn-help-symbol-info-at-point ()
   "Show full documentation for the primitve at point in a separate buffer."
   (interactive)

--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -321,12 +321,12 @@
 
 (defvar bqn-help--regexp
   (regexp-opt (append (mapcar #'cadr bqn-symbols--list)
-                      (bqn-symbols-doc--symbols)))
+                      (bqn-help--symbols)))
   "Regex to match BQN functions.")
 
 (defun bqn-help--eldoc ()
   (when (looking-at bqn-help--regexp)
-    (bqn-symbols-doc-get-short-doc (match-string 0))))
+    (bqn-help--symbol-doc-short (match-string 0))))
 
 (define-derived-mode bqn-help--mode special-mode
   "BQN Documentation"
@@ -341,8 +341,8 @@
   (unless (looking-at bqn-help--regexp)
     (user-error "No BQN primitive at point"))
   (if-let* ((symbol (match-string 0))
-            (long   (bqn-symbols-doc-get-long-doc symbol))
-            (extra  (bqn-symbols-doc-get-extra-doc symbol))
+            (long   (bqn-help--symbol-doc-long symbol))
+            (extra  (bqn-help--symbol-doc-extra symbol))
             (sep    "\n\n========================================\n\n")
             (doc-buffer (get-buffer-create "*bqn-help*")))
       (with-current-buffer doc-buffer

--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -326,7 +326,6 @@
   "Regex to match BQN functions.")
 
 (defun bqn-help--eldoc ()
-  "Return the doc string for the thing at point, or nil."
   (when (looking-at bqn-help--function-regexp)
     (bqn-symbols-doc-get-short-doc (match-string 0))))
 
@@ -335,7 +334,7 @@
   "BQN Documentation"
   "Major mode for displaying BQN documentation."
   (setq-local font-lock-defaults bqn--font-lock-defaults)
-  (setq-local eldoc-documentation-function 'bqn-help--eldoc)
+  (setq-local eldoc-documentation-function #'bqn-help--eldoc)
   (buffer-face-set 'bqn-default))
 
 ;; General interactive help
@@ -399,7 +398,7 @@ BQN buffers (or recreate them)."
     (set-keymap-parent bqn-mode-map
                        (make-composed-keymap prog-mode-map bqn--glyph-map)))
   (setq-local font-lock-defaults bqn--font-lock-defaults)
-  (setq-local eldoc-documentation-function 'bqn-help--eldoc)
+  (setq-local eldoc-documentation-function #'bqn-help--eldoc)
   (setq-local comment-start "# ")
   (buffer-face-set 'bqn-default))
 

--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -339,26 +339,22 @@
   (buffer-face-set 'bqn-default))
 
 ;; General interactive help
-(defvar bqn-help-*documentation-buffer-name* "*bqn-help*")
-
 (defun bqn-help-symbol-info-at-point ()
-  "Get multi-line documentation for the thing at point, or nil."
+  "Show full documentation for the primitve at point in a separate buffer."
   (interactive)
   (when (looking-at bqn-help--function-regexp)
     (if-let* ((symbol (match-string 0))
               (long   (bqn-symbols-doc-get-long-doc symbol))
               (extra  (bqn-symbols-doc-get-extra-doc symbol))
               (sep    "\n\n========================================\n\n")
-              (doc-buffer (get-buffer-create
-                           bqn-help-*documentation-buffer-name*)))
-        (with-current-buffer doc-buffer ;; we have a hit
-          (read-only-mode 0)            ; set read only
-          (delete-region (point-min) (point-max))
-          (insert long sep extra)
+              (doc-buffer (get-buffer-create "*bqn-help*")))
+        (with-current-buffer doc-buffer
+          (let ((inhibit-read-only t))
+            (erase-buffer)
+            (insert long sep extra))
           (goto-char (point-min))
           (bqn-help-documentation-mode)
-          (read-only-mode 1)            ; unset read only
-          (pop-to-buffer doc-buffer))
+          (display-buffer doc-buffer))
       (message "No help for %s found!" symbol))))
 
 (defun bqn--make-glyph-map (modifier)

--- a/bqn-symbols-doc.el
+++ b/bqn-symbols-doc.el
@@ -2311,9 +2311,8 @@ Examples:
       (dolist (entry table)
         (puthash (car entry) (cdr entry) ht))
       ht))
-  "This table associates BQN symbols as hash-keys to a 3-vector of docstrings.
-Position 0 is short description for eldoc, position 1 is a long description,
-and position 2 is any extra description.")
+  "Hash map from BQN symbols as keys to 3-vector of documentation strings:
+A short description for eldoc, a long description, and examples.")
 
 (defun bqn-help--symbols ()
   (let (symbols)

--- a/bqn-symbols-doc.el
+++ b/bqn-symbols-doc.el
@@ -2322,25 +2322,23 @@ and position 2 is any extra description.")
              bqn-symbols-doc--symbol-doc-table)
     symbols))
 
-(defun bqn-symbols-doc--get-doc (symbol doc)
+(defun bqn-symbols-doc--get-doc (symbol slot)
   "Retrieve a docstring for SYMBOL, given a stringp SYMBOL and a keywordp DOC.
 Return nil if no docstring is found."
-  (let ((docs (gethash symbol bqn-symbols-doc--symbol-doc-table)))
-    (and docs (aref docs (cond ((eq doc :short) 0)
-                               ((eq doc :long)  1)
-                               ((eq doc :extra) 2))))))
+  (when-let ((docs (gethash symbol bqn-symbols-doc--symbol-doc-table)))
+    (aref docs slot)))
 
 (defun bqn-symbols-doc-get-short-doc (symbol)
   "Given SYMBOL as stringp, retrieve a single-line doc string for SYMBOL, or nil."
-  (bqn-symbols-doc--get-doc symbol :short))
+  (bqn-symbols-doc--get-doc symbol 0))
 
 (defun bqn-symbols-doc-get-long-doc (symbol)
   "Given SYMBOL as stringp, retrieve a multi-line doc string for SYMBOL, or nil."
-  (bqn-symbols-doc--get-doc symbol :long))
+  (bqn-symbols-doc--get-doc symbol 1))
 
 (defun bqn-symbols-doc-get-extra-doc (symbol)
   "Given SYMBOL as stringp, retrieve a extra doc string for SYMBOL, or nil."
-  (bqn-symbols-doc--get-doc symbol :extra))
+  (bqn-symbols-doc--get-doc symbol 2))
 
 (provide 'bqn-symbols-doc)
 

--- a/bqn-symbols-doc.el
+++ b/bqn-symbols-doc.el
@@ -23,7 +23,7 @@
 ;; because we want the lowest latency possible for an end-user-facing structure.
 ;; For all intents and purposes, this table should be regarded as read-only;
 ;; indeed, it is "cached" at byte-compile time via eval-when-compile
-(defconst bqn-symbols-doc--symbol-doc-table
+(defconst bqn-help--symbol-docs
   (eval-when-compile
     (let ((table '(
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2315,30 +2315,23 @@ Examples:
 Position 0 is short description for eldoc, position 1 is a long description,
 and position 2 is any extra description.")
 
-(defun bqn-symbols-doc--symbols ()
-  "Return a list of bqn symbols for which we have docs."
+(defun bqn-help--symbols ()
   (let (symbols)
-    (maphash (lambda (sym _) (push sym symbols))
-             bqn-symbols-doc--symbol-doc-table)
+    (maphash (lambda (sym _) (push sym symbols)) bqn-help--symbol-docs)
     symbols))
 
-(defun bqn-symbols-doc--get-doc (symbol slot)
-  "Retrieve a docstring for SYMBOL, given a stringp SYMBOL and a keywordp DOC.
-Return nil if no docstring is found."
-  (when-let ((docs (gethash symbol bqn-symbols-doc--symbol-doc-table)))
+(defun bqn-help--symbol-doc (symbol slot)
+  (when-let ((docs (gethash symbol bqn-help--symbol-docs)))
     (aref docs slot)))
 
-(defun bqn-symbols-doc-get-short-doc (symbol)
-  "Given SYMBOL as stringp, retrieve a single-line doc string for SYMBOL, or nil."
-  (bqn-symbols-doc--get-doc symbol 0))
+(defun bqn-help--symbol-doc-short (symbol)
+  (bqn-help--symbol-doc symbol 0))
 
-(defun bqn-symbols-doc-get-long-doc (symbol)
-  "Given SYMBOL as stringp, retrieve a multi-line doc string for SYMBOL, or nil."
-  (bqn-symbols-doc--get-doc symbol 1))
+(defun bqn-help--symbol-doc-long (symbol)
+  (bqn-help--symbol-doc symbol 1))
 
-(defun bqn-symbols-doc-get-extra-doc (symbol)
-  "Given SYMBOL as stringp, retrieve a extra doc string for SYMBOL, or nil."
-  (bqn-symbols-doc--get-doc symbol 2))
+(defun bqn-help--symbol-doc-extra (symbol)
+  (bqn-help--symbol-doc symbol 2))
 
 (provide 'bqn-symbols-doc)
 


### PR DESCRIPTION
These are various changes to clean up eldoc and documentation facilities.

By far the most offensive change is the first commit, removing a user command --- the commit message explains the rationale.
