### PR TITLE
fix syntax-table (messed up when deriving symbols list differently)

### DIFF
--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -142,7 +142,7 @@
 
 (defvar bqn-syntax--table
   (let ((table (make-syntax-table)))
-    (dolist (s (bqn--symbols-no-doc 'all))
+    (dolist (s (bqn--symbols-no-doc))
       (modify-syntax-entry (cdr s) "." table))
     (dolist (s (string-to-list "$%&*+-/<=>|"))
       (modify-syntax-entry s "." table))


### PR DESCRIPTION
Commit 835ec19ce72a1cead2ebc9532e929b3ef28d1975 accidentally assigned many ASCII symbols (including double quotes etc) punctuation syntax --- this fixes it.