### PR TITLE
Backslash should not be an escape in BQN

### DIFF
--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -174,6 +174,7 @@
     (modify-syntax-entry ?#  "<" table)
     (modify-syntax-entry ?\n ">" table)
     (modify-syntax-entry ?'  "\"" table)
+    (modify-syntax-entry ?\\ "." table)
     table)
   "Syntax table for `bqn-mode'.")
 


### PR DESCRIPTION
The fontification was wrong with a single backslash in a character (`'\'`). This PR fixes the syntax table so that backslashes are not interpreted as escape characters.