### PR TITLE
fix: remove time argument to accept-process-output

### DIFF
--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -389,7 +389,7 @@ With non-nil prefix ARG, switch to the process buffer."
      ;; Wait for the process to complete
      (with-current-buffer (process-buffer process)
        (while (and (null comint-redirect-completed)
-                 (accept-process-output process 0.1))))
+                 (accept-process-output process))))
      (goto-char (point-min))
      ;; Get output while skipping the next prompt
      (when bqn-font-lock-eval


### PR DESCRIPTION
A mini PR. Setting the time argument to 0.1 throws an error if the command's execution takes longer than that in the coming buffer. This is the result of `tdoe`:

```elisp
Debugger entered--Lisp error: (error "Selecting deleted buffer")
  comint-redirect-preoutput-filter("@\n")
  comint-redirect-filter(comint-output-filter #<process BQN> "@\n")
  apply(comint-redirect-filter comint-output-filter (#<process BQN> "@\n"))
  #f(advice comint-redirect-filter :around comint-output-filter)(#<process BQN> "@\n")
```

By using the default, the error disappears.