### PR TITLE
Add `bqn-comint-bring`

### DIFF
--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -304,11 +304,28 @@ BQN buffers (or recreate them)."
   :type 'boolean
   :group 'bqn)
 
+(defun bqn--comint-prefix ()
+  "The prefix for BQNs comint buffers."
+  (concat "*" bqn-comint--process-name "-"))
+
+(defconst bqn--comint-suffix "*"
+  "The suffix for BQNs comint buffers.")
+
+(defun bqn--comint-buffer-name ()
+  "Return the name of the comint buffer associated to the current buffer.
+Note that the comint buffer may not exist yet, use `bqn-comint-buffer'
+to create it."
+  (let* ((pref (bqn--comint-prefix))
+         (buf (or (buffer-file-name) (buffer-name))))
+    (if (string-prefix-p pref buf)
+        buf
+      (concat pref buf bqn--comint-suffix))))
+
 ;;;###autoload
 (defun bqn-comint-buffer ()
   "Run an inferior BQN process inside Emacs and return its buffer."
   (interactive)
-  (let ((buf-name (concat "*" bqn-comint--process-name "*")))
+  (let ((buf-name (bqn--comint-buffer-name)))
     ;; same buffer name as auto-created when passing nil below
     (if-let ((buf (get-buffer buf-name)))
         (if (comint-check-proc buf)

--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -266,6 +266,7 @@ BQN buffers (or recreate them)."
   (when bqn-glyph-map-modifier
     (set-keymap-parent bqn-mode-map
                        (make-composed-keymap prog-mode-map bqn--glyph-map)))
+  (keymap-set bqn-mode-map "C-c C-z" #'bqn-comint-bring)
   (when bqn-use-input-method
     (activate-input-method "BQN-Z"))
   (setq-local syntax-propertize-function bqn--syntax-propertize)
@@ -449,6 +450,17 @@ bqn-comint-process-session and echoes the result."
   (interactive)
   (bqn-comint-eval-region (point-min) (point-max)))
 
+(defun bqn-comint-bring ()
+  "Toggle between the comint buffer and its associated buffer."
+  (interactive)
+  (let* ((comint (bqn-comint-buffer))
+         (buf (thread-last
+                (buffer-name comint)
+                (string-remove-prefix (bqn--comint-prefix))
+                (string-remove-suffix bqn--comint-suffix)
+                get-file-buffer)))
+    (pop-to-buffer (if (equal (current-buffer) comint) buf comint))))
+
 (define-derived-mode bqn-comint-mode comint-mode "BQN interactive"
   "Major mode for inferior BQN processes."
   :syntax-table bqn--syntax-table
@@ -456,6 +468,7 @@ bqn-comint-process-session and echoes the result."
   (when bqn-glyph-map-modifier
     (set-keymap-parent bqn-comint-mode-map
                        (make-composed-keymap comint-mode-map bqn--glyph-map)))
+  (keymap-set bqn-comint-mode-map "C-c C-z" #'bqn-comint-bring)
   (when bqn-use-input-method
     (activate-input-method "BQN-Z"))
   (setq-local syntax-propertize-function bqn--syntax-propertize)


### PR DESCRIPTION
Lots of other major modes with REPL-like functionality have some way to toggle between it and the buffer it's associated to. This is something I missed from `bqn-mode`, so here we are. 

Additionally, there is a breaking change lurking here, technically: the BQN comint process is now associated to a particular buffer, instead of being global. In my opinion, this is much more natural anyways, but YMMV. Of course, this can always be made into a backwards-compatible toggle.

### Commit Summary

#### [Create a unique BQN comint process per buffer](https://github.com/museoa/bqn-mode/commit/8f861adf53f2a3e60e8c4279fc086ef072bdc283)

Instead of one unique `*BQN*` buffer, create a new one for every buffer. This feels more intuitive than all sessions sharing the global instance, especially when using system functions that actually talk to the OS—which directory one is in matters.

#### [Add bqn-comint-bring](https://github.com/museoa/bqn-mode/commit/4273c572f15715640ca4269be64a4624eb775e24) 

Toggle between the comint buffer and its associated buffer. Bound to `C-c C-z` by default, as this seems to be quite common among other major modes.