### PR TITLE
Explicitly require `subr-x`

### DIFF
--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -19,6 +19,7 @@
 (require 'comint)
 (require 'quail)
 (require 'pulse)
+(require 'subr-x)
 
 (defvar bqn-keymap-mode-reference
   "\


### PR DESCRIPTION
## TL;DR
This change adds `'subr-x` to the list of `require`d libraries so `thread-last` byte-compiles as expected in `bqn-comint-bring`.

## Explanation
I've recently worked at porting this package to [Guix](https://guix.gnu.org/) and found a weird issue where due to the way Guix build Emacs packages `bqn-comint-bring` would error out. I tracked the issue down to `thread-last` not byte-compiling correctly. I don't really know much about Emacs byte compilation but what I do know is that the `thread-last` macro isn't auto-loaded from `subr-x` by default, and manually requiring it solved the issue.

## Risks/Breaking Changes
I can't think of any