### PR TITLE
bqn-comint-buffer: Wait for prompt

### DIFF
--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -2705,7 +2705,15 @@ to create it."
                     bqn-comint--process-name buf-name
                     bqn-interpreter nil bqn-interpreter-arguments)))
         (with-current-buffer buf
-          (bqn-comint-mode))
+          (bqn-comint-mode)
+          ;; Wait for prompt.
+          (let ((proc (get-buffer-process buf)))
+            (while (and (process-live-p proc)
+                        (save-excursion
+                          (goto-char (point-max))
+                          (forward-line 0)
+                          (not (looking-at-p comint-prompt-regexp))))
+              (accept-process-output proc 0.05))))
         buf))))
 
 (defun bqn-comint--escape (str)

--- a/bqn-mode.el
+++ b/bqn-mode.el
@@ -2546,9 +2546,9 @@ https://mlochbaum.github.io/BQN/help/index.html.")
 
 (defun bqn--eldoc ()
   (let ((c (char-after (point))))
-    (when-let ((docs (bqn--symbol c)))
+    (when-let* ((docs (bqn--symbol c)))
       (concat (bqn--symbol-eldoc docs) " | Input: "
-              (if-let ((prefixed (bqn--symbol-prefixed docs)))
+              (if-let* ((prefixed (bqn--symbol-prefixed docs)))
                   (string bqn-glyph-prefix prefixed)
                 (string c))))))
 
@@ -2696,7 +2696,7 @@ to create it."
   (interactive)
   (let ((buf-name (bqn--comint-buffer-name)))
     ;; same buffer name as auto-created when passing nil below
-    (if-let ((buf (get-buffer buf-name)))
+    (if-let* ((buf (get-buffer buf-name)))
         (if (comint-check-proc buf)
             buf
           (error "Buffer '%s' exists but has no live process" buf-name))


### PR DESCRIPTION
If we don't do this, comint tries to look for its prompt regexp too early (i.e., before BQN has returned anything), and fails with

    comint-redirect-send-command-to-process: No prompt found or ‘comint-prompt-regexp’ not set properly

the first time when sending something to a new BQN process.

Lifted from @Panadestein's [config](https://github.com/Panadestein/emacsd/blob/master/content/index.org#bqn) (which is under GPLv3 as well)